### PR TITLE
expose detect_trace_type as public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Use only the pieces you need:
 | --- | --- |
 | Generate coding-agent traces | `teich generate` with `agent.provider: codex`, `pi`, `claude-code`, or `hermes` |
 | Generate text-only chat rows | `teich generate` with `agent.provider: chat` |
+| Detect supported raw trace events | `detect_trace_type()` |
 | Load raw traces manually | `load_traces()` |
 | Prepare local/HF/mixed datasets for training | `prepare_data()` |
 | Apply response-only labels after TRL/Unsloth tokenization | `mask_data()` |
@@ -530,6 +531,7 @@ Assistant messages capture:
 from teich import (
     prepare_data,        # Recommended: render trainer-friendly text rows
     mask_data,           # Recommended: apply Teich labels after SFTTrainer tokenization
+    detect_trace_type,   # Detect supported parsed trace events, or return None
     load_traces,         # Fallback: load rows for fully manual processing
     row_fits_context,    # Public chat-template render + token fit check for one row
     validate_tool_calls, # Validate tool-call names and required arguments
@@ -539,6 +541,8 @@ from teich import (
     TrainingExample,     # Typed training example
 )
 ```
+
+`detect_trace_type(events)` returns `codex`, `claude_code`, `pi`, `hermes`, or `external_agent` for supported parsed trace events, and `None` for ordinary JSON rows.
 
 `README.md` is the package readme used for PyPI, so these examples are the canonical public package docs.
 

--- a/src/teich/__init__.py
+++ b/src/teich/__init__.py
@@ -4,7 +4,7 @@ __version__ = "0.1.1a77"
 
 from .audit import SFTAuditReport, audit_sft_dataset
 from .config import Config, load_config
-from .converter import TrainingExample, convert_trace_to_training_example, convert_traces_to_training_data
+from .converter import TrainingExample, convert_trace_to_training_example, convert_traces_to_training_data, detect_trace_type
 from .formatter import PrepareReport, RowContextFit, mask_data, preview_sft_example, row_fits_context
 from .loader import load_traces, trace_is_complete
 from .prepare import prepare_data
@@ -20,6 +20,7 @@ __all__ = [
     "audit_sft_dataset",
     "convert_trace_to_training_example",
     "convert_traces_to_training_data",
+    "detect_trace_type",
     "load_traces",
     "load_config",
     "mask_data",

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -5,11 +5,12 @@ import re
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 
 _INLINE_THINKING_BLOCK_PATTERN = re.compile(r"<(think|thinking)>(.*?)</\1>", re.DOTALL)
 PI_SYSTEM_PROMPT_CUSTOM_TYPE = "teich-system-prompt"
+TraceType = Literal["claude_code", "codex", "external_agent", "hermes", "pi"]
 
 _CLAUDE_CODE_BUILTIN_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "Task": {
@@ -691,7 +692,7 @@ def _claude_code_tool_schema_from_definition(tool: dict[str, Any]) -> dict[str, 
     return schema
 
 
-def _detect_trace_type(events: list[dict[str, Any]]) -> str:
+def _detect_trace_type(events: list[Any], default: TraceType | None = "codex") -> TraceType | None:
     for event in events:
         if _is_hermes_conversation(event):
             return "hermes"
@@ -731,7 +732,11 @@ def _detect_trace_type(events: list[dict[str, Any]]) -> str:
             "label",
         }:
             return "pi"
-    return "codex"
+    return default
+
+
+def detect_trace_type(events: list[Any]) -> TraceType | None:
+    return _detect_trace_type(events, default=None)
 
 
 def _claude_text_from_content(content: Any) -> str:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,7 +1,30 @@
 import json
 from pathlib import Path
 
+from teich import detect_trace_type
 from teich.converter import convert_trace_to_training_example, convert_traces_to_training_data
+
+
+def test_detect_trace_type_returns_known_trace_type():
+    cases = [
+        ([{"type": "session_meta", "payload": {"id": "codex-session"}}], "codex"),
+        (
+            [{"type": "user", "session_id": "claude-session", "message": {"role": "user", "content": "hello"}}],
+            "claude_code",
+        ),
+        ([{"type": "session", "id": "pi-session"}], "pi"),
+        (
+            [{"id": "hermes-session", "source": "cli", "messages": [{"role": "user", "content": "hello"}]}],
+            "hermes",
+        ),
+    ]
+
+    for events, expected_trace_type in cases:
+        assert detect_trace_type(events) == expected_trace_type
+
+
+def test_detect_trace_type_returns_none_for_non_agent_jsonl():
+    assert detect_trace_type([{"text": "hello"}, {"text": "world"}]) is None
 
 
 def test_convert_pi_trace_ignores_malformed_tool_calls(tmp_path: Path):


### PR DESCRIPTION
The `detect_trace_type` can be quite useful for places like [datasets](https://github.com/huggingface/datasets/blob/71880a446f44cf722e584459a18fbecceeefdc32/src/datasets/packaged_modules/json/json.py#L315-L323), where Teich could own trace detection instead of copying format-specific marker checks downstream. Let me know if this makes sense 🤗

```python
import json
from pathlib import Path
from teich import detect_trace_type

events = [
    json.loads(line)
    for line in Path("session.jsonl").read_text(encoding="utf-8").splitlines()
    if line.strip()
]

print(f"trace_type={detect_trace_type(events)}")
```

