### PR TITLE
Add first message timestamp metadata to trace records

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -217,6 +217,7 @@ Important details:
 - **`teich_supervised_spans`** are typed character span metadata. `prepare_data()` records candidate spans; `mask_data()` decides which kinds become labels.
 - **`teich_masking=False`** skips span metadata and returns plain rendered `text` rows for standard next-token training without Teich labels.
 - **Original columns are removed** after formatting unless `preserve_columns=True` or an explicit `preserve_columns=[...]` list is passed. `source`, `metadata`, `raw_index`, and `source_key` are the default provenance columns.
+- **Raw trace conversion** stores `metadata.first_message_timestamp` when a source user message has its own timestamp. It is not synthesized from session-start metadata.
 - **Oversized examples use `oversized_policy`** when `max_length` is set: `"drop"`, `"trim_followups"`, or `"error"`. The older `drop_oversized_examples` and `trim_oversized_followups` flags still work as aliases.
 - **Preparation reports** are available with `return_report=True`. The returned `PrepareReport` includes dropped rows, oversized rows, trimmed rows, token lengths, max token lengths, kept-row ids, and returned row count.
 - **Public preflight helpers**: `row_fits_context(row, tokenizer, max_length, chat_template_kwargs)` renders and measures one row, `validate_tool_calls(row)` checks declared tool names and required args, and `trace_is_complete(row)` flags rows that end on a tool result.

--- a/README.md
+++ b/README.md
@@ -523,6 +523,8 @@ Training examples include:
 - `tools`: tool schemas available to the session, including tools that were not called
 - `metadata`: session info, model, timestamps, and usage when available
 
+When the source format exposes per-message timestamps, converted rows include `metadata.first_message_timestamp` from the first timestamp-bearing source event that becomes a user message.
+
 Structured chat datasets can also include convenience top-level fields like:
 
 - `system` when provided by the prompt row

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -2,17 +2,21 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
 
 _INLINE_THINKING_BLOCK_PATTERN = re.compile(r"<(think|thinking)>(.*?)</\1>", re.DOTALL)
+FIRST_MESSAGE_TIMESTAMP_METADATA_KEY = "first_message_timestamp"
 PI_SYSTEM_PROMPT_CUSTOM_TYPE = "teich-system-prompt"
 TEICH_AVAILABLE_TOOLS_CUSTOM_TYPE = "teich-available-tools"
 TEICH_TRACE_CONTEXT_ITEM_TYPE = "teich_context"
 TraceType = Literal["claude_code", "codex", "external_agent", "hermes", "openclaw", "pi"]
+_TIMESTAMP_KEYS = ("timestamp", "created_at", "createdAt")
 
 _CLAUDE_CODE_BUILTIN_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "Task": {
@@ -257,6 +261,71 @@ class TrainingExample:
             "tools": self.tools,
             "metadata": self.metadata,
         }
+
+
+def _normalize_timestamp_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    timestamp = float(value)
+    if timestamp > 10_000_000_000:
+        timestamp /= 1000
+    try:
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _timestamp_from_mapping(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    for key in _TIMESTAMP_KEYS:
+        timestamp = _normalize_timestamp_value(value.get(key))
+        if timestamp:
+            return timestamp
+    return None
+
+
+def _event_timestamp(event: Any) -> str | None:
+    if not isinstance(event, dict):
+        return None
+    timestamp = _timestamp_from_mapping(event)
+    if timestamp:
+        return timestamp
+    for key in ("payload", "message"):
+        timestamp = _timestamp_from_mapping(event.get(key))
+        if timestamp:
+            return timestamp
+    return None
+
+
+def _first_message_timestamp_from_events(events: list[Any], predicate: Callable[[dict[str, Any]], bool]) -> str | None:
+    for event in events:
+        if isinstance(event, dict) and predicate(event):
+            timestamp = _event_timestamp(event)
+            if timestamp:
+                return timestamp
+    return None
+
+
+def _add_first_message_timestamp(metadata: dict[str, Any], timestamp: str | None) -> None:
+    if timestamp:
+        metadata[FIRST_MESSAGE_TIMESTAMP_METADATA_KEY] = timestamp
+
+
+def _is_user_role(role: Any) -> bool:
+    return isinstance(role, str) and _normalize_role(role) == "user"
+
+
+def _is_external_user_message(event: dict[str, Any]) -> bool:
+    return event.get("type") == "external_message" and _is_user_role(event.get("role"))
+
+
+def _is_nested_user_message(event: dict[str, Any]) -> bool:
+    message = event.get("message")
+    return isinstance(message, dict) and _is_user_role(message.get("role"))
 
 
 def _first_text_block(content_blocks: Any) -> str:
@@ -572,6 +641,21 @@ def _codex_event_msg_payload_type(event: dict[str, Any]) -> str | None:
         return None
     payload_type = payload.get("type")
     return payload_type if isinstance(payload_type, str) else None
+
+
+def _codex_first_user_message_timestamp(events: list[Any]) -> str | None:
+    timestamp = _first_message_timestamp_from_events(
+        events,
+        lambda event: _codex_event_msg_payload_type(event) == "user_message",
+    )
+    if timestamp:
+        return timestamp
+    return _first_message_timestamp_from_events(
+        events,
+        lambda event: _codex_payload_type(event) == "message"
+        and isinstance(event.get("payload"), dict)
+        and _is_user_role(event["payload"].get("role")),
+    )
 
 
 def _codex_assistant_prefix_marker(event: dict[str, Any]) -> bool:
@@ -1231,6 +1315,10 @@ def _convert_claude_code_trace_to_training_example(
     usage: dict[str, Any] | None = None
     total_cost_usd: Any = None
     prompt = ""
+    first_message_timestamp = _first_message_timestamp_from_events(
+        events,
+        lambda event: _is_external_user_message(event) or (event.get("type") == "user" and _is_nested_user_message(event)),
+    )
 
     for event in events:
         if not isinstance(event, dict):
@@ -1415,6 +1503,7 @@ def _convert_claude_code_trace_to_training_example(
         metadata["usage"] = usage
     if total_cost_usd is not None:
         metadata["total_cost_usd"] = total_cost_usd
+    _add_first_message_timestamp(metadata, first_message_timestamp)
     return TrainingExample(
         source_file=trace_file,
         prompt=prompt,
@@ -1459,6 +1548,10 @@ def _convert_hermes_trace_to_training_example(
         session_meta = {key: value for key, value in events[0].items() if key != "messages"}
         _add_explicit_tools(events[0].get("tools"), explicit_tools, tool_names, tool_schemas)
         message_events = [event for event in events[0]["messages"] if isinstance(event, dict)]
+    first_message_timestamp = _first_message_timestamp_from_events(
+        message_events,
+        lambda event: _is_user_role(event.get("role")),
+    )
 
     for event in message_events:
         if not isinstance(event, dict):
@@ -1577,6 +1670,7 @@ def _convert_hermes_trace_to_training_example(
         "system_prompt": session_meta.get("system_prompt"),
         "turn_count": sum(1 for message in messages if message.get("role") == "user"),
     }
+    _add_first_message_timestamp(metadata, first_message_timestamp)
     return TrainingExample(
         source_file=trace_file,
         prompt=prompt,
@@ -1632,25 +1726,33 @@ def _hermes_conversation_to_events(conversation: Any) -> list[dict[str, Any]]:
     for item in conversation:
         source_role = item.get("from")
         value = item.get("value") or ""
+        timestamp = _timestamp_from_mapping(item)
         if source_role == "system":
-            events.append({"role": "system", "content": value})
+            event = {"role": "system", "content": value}
+            if timestamp:
+                event["timestamp"] = timestamp
+            events.append(event)
         elif source_role == "human":
-            events.append({"role": "user", "content": value})
+            event = {"role": "user", "content": value}
+            if timestamp:
+                event["timestamp"] = timestamp
+            events.append(event)
         elif source_role == "tool":
             tool_blocks, fallback_content = _extract_xml_blocks(value, "tool_response")
             parsed = _normalize_json_like_value(tool_blocks[0]) if tool_blocks else fallback_content
             if not isinstance(parsed, dict):
                 parsed = {"content": parsed}
-            events.append(
-                {
-                    "role": "tool",
-                    "content": json.dumps(parsed.get("content"), ensure_ascii=False)
-                    if isinstance(parsed.get("content"), (dict, list))
-                    else str(parsed.get("content") or ""),
-                    "tool_call_id": parsed.get("tool_call_id"),
-                    "tool_name": parsed.get("name"),
-                }
-            )
+            event = {
+                "role": "tool",
+                "content": json.dumps(parsed.get("content"), ensure_ascii=False)
+                if isinstance(parsed.get("content"), (dict, list))
+                else str(parsed.get("content") or ""),
+                "tool_call_id": parsed.get("tool_call_id"),
+                "tool_name": parsed.get("name"),
+            }
+            if timestamp:
+                event["timestamp"] = timestamp
+            events.append(event)
         elif source_role == "gpt":
             thinking_blocks, without_thinking = _extract_xml_blocks(value, "think")
             tool_blocks, content = _extract_xml_blocks(without_thinking, "tool_call")
@@ -1677,6 +1779,8 @@ def _hermes_conversation_to_events(conversation: Any) -> list[dict[str, Any]]:
                 event["reasoning_content"] = "\n\n".join(block for block in thinking_blocks if block)
             if tool_calls:
                 event["tool_calls"] = tool_calls
+            if timestamp:
+                event["timestamp"] = timestamp
             events.append(event)
     return events
 
@@ -1692,6 +1796,10 @@ def _convert_external_agent_trace_to_training_example(
     explicit_tools: dict[str, dict[str, Any]] = {}
     session_meta: dict[str, Any] = {}
     prompt = ""
+    first_message_timestamp = _first_message_timestamp_from_events(
+        events,
+        _is_external_user_message,
+    )
     for event in events:
         if not isinstance(event, dict):
             continue
@@ -1808,6 +1916,7 @@ def _convert_external_agent_trace_to_training_example(
         "api_call_count": session_meta.get("api_call_count"),
         "turn_count": sum(1 for message in messages if message.get("role") == "user"),
     }
+    _add_first_message_timestamp(metadata, first_message_timestamp)
     return TrainingExample(
         source_file=trace_file,
         prompt=prompt,
@@ -1833,6 +1942,7 @@ def _convert_codex_trace_to_training_example(
     events: list[dict[str, Any]],
 ) -> TrainingExample:
     events = normalize_codex_trace_events(events)
+    first_message_timestamp = _codex_first_user_message_timestamp(events)
     messages: list[dict[str, Any]] = []
     pending_reasoning_parts: list[str] = []
     tool_names: set[str] = set()
@@ -2018,6 +2128,7 @@ def _convert_codex_trace_to_training_example(
         "system_prompt": system_prompt or session_meta.get("system_prompt"),
         "turn_count": len(turn_contexts),
     }
+    _add_first_message_timestamp(metadata, first_message_timestamp)
     return TrainingExample(
         source_file=trace_file,
         prompt=prompt,
@@ -2047,6 +2158,10 @@ def _convert_pi_trace_to_training_example(
     prompt = ""
     invalid_tool_call_ids: set[str] = set()
     include_teich_pi_metadata = trace_type == "pi"
+    first_message_timestamp = _first_message_timestamp_from_events(
+        events,
+        lambda event: event.get("type") == "message" and _is_nested_user_message(event),
+    )
 
     for event in events:
         if not isinstance(event, dict) or event.get("type") != "message":
@@ -2209,6 +2324,7 @@ def _convert_pi_trace_to_training_example(
     if session_names:
         metadata["session_names"] = session_names
         metadata["session_name"] = session_names[-1]
+    _add_first_message_timestamp(metadata, first_message_timestamp)
     return TrainingExample(
         source_file=trace_file,
         prompt=prompt,
@@ -2293,7 +2409,12 @@ def _structured_training_example_from_row(
     row: dict[str, Any],
     row_index: int,
 ) -> TrainingExample:
-    messages = normalize_training_messages(row.get("messages"))
+    raw_messages = row.get("messages")
+    first_message_timestamp = _first_message_timestamp_from_events(
+        raw_messages if isinstance(raw_messages, list) else [],
+        lambda message: _is_user_role(message.get("role")),
+    )
+    messages = normalize_training_messages(raw_messages)
     if not messages:
         system = row.get("system")
         if isinstance(system, str) and system.strip():
@@ -2321,6 +2442,8 @@ def _structured_training_example_from_row(
         "trace_type",
         "chat" if any(key in row for key in ("system", "thinking", "response", "model")) and not tools else "structured",
     )
+    if first_message_timestamp:
+        metadata.setdefault(FIRST_MESSAGE_TIMESTAMP_METADATA_KEY, first_message_timestamp)
     return TrainingExample(
         source_file=source_file,
         prompt=prompt,

--- a/src/teich/trace_readme.py
+++ b/src/teich/trace_readme.py
@@ -282,7 +282,8 @@ def build_traces_readme(
                 "- `task`: first user prompt extracted from the trace",
                 "- `traces`: native conversation messages in `from` / `value` form",
                 "- `tools`: the tool schema available to that session, including tools that were not called",
-                "- `metadata`: provider, model, token, cost, parent-session, and export details",
+                "- `metadata`: provider, model, first-message timestamp, token, cost, parent-session, and export details",
+                "- `metadata.first_message_timestamp`: first timestamp-bearing source user message when the trace format provides one",
                 "",
             ]
         )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -92,6 +92,7 @@ def test_convert_openclaw_trace_uses_distinct_type_with_shared_event_envelope(tm
             "id": "user-1",
             "message": {
                 "role": "user",
+                "timestamp": 1771285243795,
                 "content": [{"type": "text", "text": "Hi"}],
             },
         },
@@ -118,6 +119,7 @@ def test_convert_openclaw_trace_uses_distinct_type_with_shared_event_envelope(tm
     assert example.metadata["model"] == "claude-opus-4-6"
     assert example.metadata["cwd"] == "/Users/calebfahlgren/.openclaw/workspace"
     assert example.metadata["thinking_level"] == "low"
+    assert example.metadata["first_message_timestamp"] == "2026-02-16T23:40:43.795000Z"
     assert "system_prompt" not in example.metadata
     assert example.prompt == "Hi"
     assert example.tools == []
@@ -379,11 +381,17 @@ def test_convert_codex_trace_keeps_system_prompt_and_tools_without_tool_calls(tm
         },
         {
             "type": "response_item",
+            "timestamp": "2026-05-13T06:03:00.000Z",
             "payload": {
                 "type": "message",
                 "role": "user",
                 "content": [{"type": "input_text", "text": "Say hi"}],
             },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-05-13T06:03:06.000Z",
+            "payload": {"type": "user_message", "message": "Say hi"},
         },
         {
             "type": "response_item",
@@ -415,6 +423,7 @@ def test_convert_codex_trace_keeps_system_prompt_and_tools_without_tool_calls(tm
 
     assert example.messages[0] == {"role": "system", "content": "You are a careful coding agent."}
     assert example.metadata["system_prompt"] == "You are a careful coding agent."
+    assert example.metadata["first_message_timestamp"] == "2026-05-13T06:03:06.000Z"
     assert [tool["function"]["name"] for tool in example.tools] == ["exec_command"]
     assert example.tools[0]["function"]["parameters"]["required"] == ["cmd"]
 
@@ -506,7 +515,12 @@ def test_convert_claude_code_stream_json_trace(tmp_path: Path):
                 "cwd": "/workspace",
             },
         },
-        {"type": "external_message", "role": "user", "content": "Inspect the project"},
+        {
+            "type": "external_message",
+            "role": "user",
+            "content": "Inspect the project",
+            "timestamp": "2026-05-14T00:00:01.000Z",
+        },
         {
             "type": "system",
             "subtype": "init",
@@ -552,6 +566,7 @@ def test_convert_claude_code_stream_json_trace(tmp_path: Path):
     assert example.metadata["trace_type"] == "claude-code"
     assert example.metadata["session_id"] == "claude-session"
     assert example.metadata["model_provider"] == "anthropic"
+    assert example.metadata["first_message_timestamp"] == "2026-05-14T00:00:01.000Z"
     assert example.prompt == "Inspect the project"
     assert example.messages[0] == {"role": "user", "content": "Inspect the project"}
     assert example.messages[1]["role"] == "assistant"
@@ -780,7 +795,12 @@ def test_convert_external_agent_trace(tmp_path: Path):
                 "model": "qwen/qwen3-coder",
             },
         },
-        {"type": "external_message", "role": "user", "content": "Build a CLI"},
+        {
+            "type": "external_message",
+            "role": "user",
+            "content": "Build a CLI",
+            "timestamp": "2026-05-15T00:00:01.000Z",
+        },
         {"type": "external_message", "role": "assistant", "content": "Built it."},
     ]
     trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
@@ -789,6 +809,7 @@ def test_convert_external_agent_trace(tmp_path: Path):
 
     assert example.metadata["trace_type"] == "hermes-agent"
     assert example.metadata["session_id"] == "hermes-session"
+    assert example.metadata["first_message_timestamp"] == "2026-05-15T00:00:01.000Z"
     assert example.prompt == "Build a CLI"
     assert example.messages == [
         {"role": "user", "content": "Build a CLI"},
@@ -935,7 +956,7 @@ def test_convert_hermes_native_trace_preserves_raw_messages_and_metadata(tmp_pat
     }
     conversation = [
         {"from": "system", "value": "Use the delegated task contract."},
-        {"from": "human", "value": "Delegate a task"},
+        {"from": "human", "value": "Delegate a task", "timestamp": "2026-05-16T00:00:01.000Z"},
         {
             "from": "gpt",
             "value": '<think>\nNeed isolated context.\n</think>\n<tool_call>\n{"name": "delegate_task", "arguments": {"prompt": "sub task"}}\n</tool_call>',
@@ -981,6 +1002,7 @@ def test_convert_hermes_native_trace_preserves_raw_messages_and_metadata(tmp_pat
     assert example.metadata["billing_base_url"] == "https://openrouter.ai/api/v1"
     assert example.metadata["estimated_cost_usd"] == 0.001
     assert example.metadata["system_prompt"] == "Use the delegated task contract."
+    assert example.metadata["first_message_timestamp"] == "2026-05-16T00:00:01.000Z"
     assert example.prompt == "Delegate a task"
     assert example.messages[2]["tool_calls"][0]["function"] == {
         "name": "delegate_task",
@@ -1757,6 +1779,7 @@ def test_convert_pi_trace_uses_thinking_blocks_and_tool_results(tmp_path: Path):
             "id": "user-1",
             "message": {
                 "role": "user",
+                "timestamp": "2026-05-17T00:00:01.000Z",
                 "content": [{"type": "text", "text": "Review this repo"}],
             },
         },
@@ -1796,6 +1819,7 @@ def test_convert_pi_trace_uses_thinking_blocks_and_tool_results(tmp_path: Path):
     assert example.metadata["trace_type"] == "pi"
     assert example.metadata["model_provider"] == "anthropic"
     assert example.metadata["thinking_level"] == "high"
+    assert example.metadata["first_message_timestamp"] == "2026-05-17T00:00:01.000Z"
     assert example.messages[0]["role"] == "system"
     assert "Available tools:" in example.messages[0]["content"]
     assert example.messages[2]["role"] == "assistant"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -245,8 +245,18 @@ def test_load_traces_loads_structured_chat_dataset_file(tmp_path: Path):
                 json.dumps(
                     {
                         "messages": [
-                            {"role": "system", "content": "You are a helpful assistant", "thinking": None},
-                            {"role": "user", "content": "Hello", "thinking": None},
+                            {
+                                "role": "system",
+                                "content": "You are a helpful assistant",
+                                "thinking": None,
+                                "timestamp": "2026-05-18T00:00:01.000Z",
+                            },
+                            {
+                                "role": "user",
+                                "content": "Hello",
+                                "thinking": None,
+                                "timestamp": "2026-05-18T00:00:02.000Z",
+                            },
                             {"role": "assistant", "content": "Hi!", "thinking": "I should greet the user."},
                         ],
                         "system": "You are a helpful assistant",
@@ -274,6 +284,7 @@ def test_load_traces_loads_structured_chat_dataset_file(tmp_path: Path):
     assert row["metadata"]["trace_type"] == "chat"
     assert row["metadata"]["model"] == "gpt-4.1-mini"
     assert row["metadata"]["usage"]["prompt_tokens"] == 4
+    assert row["metadata"]["first_message_timestamp"] == "2026-05-18T00:00:02.000Z"
 
 
 def test_load_traces_normalizes_separate_assistant_thinking_field(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Add `metadata.first_message_timestamp` when source trace user messages expose their own timestamp.
- Cover Codex, Pi/OpenClaw, Claude Code, Hermes/external traces, and structured chat rows.
- Document the field in the README, DOCS, and generated trace README text.

## Behavior
- Uses the first timestamp-bearing source event that becomes a user message.
- For Codex, prefers `event_msg` `user_message` records over `response_item` user messages so context payloads do not win over the actual user prompt.
- Preserves string timestamps as provided.
- Normalizes numeric epoch seconds/milliseconds to UTC ISO timestamps.
- Leaves the field absent when only session-level timestamps are available.

Fixes #3

## Validation
- `uv run pytest tests/test_converter.py tests/test_loader.py tests/test_trace_readme.py`
- `uv run pytest`
- `uv run ruff check .`
- `git diff --check`
- Live smoke: `load_traces("cfahlgren1/openclaw-test")` returns `metadata.trace_type == "openclaw"`, `metadata.first_message_timestamp == "2026-02-16T23:40:43.798Z"`, no `system_prompt`, and `tools == []`.