### PR TITLE
Fix first message timestamp edge cases

### DIFF
--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -291,14 +291,11 @@ def _timestamp_from_mapping(value: Any) -> str | None:
 def _event_timestamp(event: Any) -> str | None:
     if not isinstance(event, dict):
         return None
-    timestamp = _timestamp_from_mapping(event)
-    if timestamp:
-        return timestamp
     for key in ("payload", "message"):
         timestamp = _timestamp_from_mapping(event.get(key))
         if timestamp:
             return timestamp
-    return None
+    return _timestamp_from_mapping(event)
 
 
 def _first_message_timestamp_from_events(events: list[Any], predicate: Callable[[dict[str, Any]], bool]) -> str | None:
@@ -326,6 +323,17 @@ def _is_external_user_message(event: dict[str, Any]) -> bool:
 def _is_nested_user_message(event: dict[str, Any]) -> bool:
     message = event.get("message")
     return isinstance(message, dict) and _is_user_role(message.get("role"))
+
+
+def _is_claude_code_user_message(event: dict[str, Any]) -> bool:
+    if event.get("type") != "user" or not _is_nested_user_message(event):
+        return False
+    message = event.get("message")
+    content = message.get("content") if isinstance(message, dict) else None
+    return not (
+        isinstance(content, list)
+        and any(isinstance(block, dict) and block.get("type") == "tool_result" for block in content)
+    )
 
 
 def _first_text_block(content_blocks: Any) -> str:
@@ -1317,7 +1325,7 @@ def _convert_claude_code_trace_to_training_example(
     prompt = ""
     first_message_timestamp = _first_message_timestamp_from_events(
         events,
-        lambda event: _is_external_user_message(event) or (event.get("type") == "user" and _is_nested_user_message(event)),
+        lambda event: _is_external_user_message(event) or _is_claude_code_user_message(event),
     )
 
     for event in events:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -90,6 +90,7 @@ def test_convert_openclaw_trace_uses_distinct_type_with_shared_event_envelope(tm
         {
             "type": "message",
             "id": "user-1",
+            "timestamp": "2026-02-16T23:40:43.700Z",
             "message": {
                 "role": "user",
                 "timestamp": 1771285243795,
@@ -591,6 +592,51 @@ def test_convert_claude_code_stream_json_trace(tmp_path: Path):
     assert bash_tool["function"]["parameters"]["properties"]["command"]["type"] == "string"
     todo_tool = next(tool for tool in example.tools if tool["function"]["name"] == "TodoWrite")
     assert todo_tool["function"]["parameters"]["properties"]["todos"]["type"] == "array"
+
+
+def test_convert_claude_code_trace_ignores_tool_result_timestamp_for_first_message(tmp_path: Path):
+    trace_file = tmp_path / "claude-code-tool-result-timestamp.jsonl"
+    events = [
+        {
+            "type": "user",
+            "session_id": "claude-session",
+            "message": {
+                "role": "user",
+                "content": "Inspect the project",
+            },
+        },
+        {
+            "type": "assistant",
+            "session_id": "claude-session",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls"}}],
+            },
+        },
+        {
+            "type": "user",
+            "session_id": "claude-session",
+            "timestamp": "2026-05-14T00:00:02.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": "README.md\nsrc"},
+                ],
+            },
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    assert example.prompt == "Inspect the project"
+    assert "first_message_timestamp" not in example.metadata
+    assert example.messages[2] == {
+        "role": "tool",
+        "tool_call_id": "toolu_1",
+        "name": "unknown_tool",
+        "content": "README.md\nsrc",
+    }
 
 
 def test_convert_claude_code_keeps_init_tools_without_tool_calls(tmp_path: Path):
@@ -1777,6 +1823,7 @@ def test_convert_pi_trace_uses_thinking_blocks_and_tool_results(tmp_path: Path):
         {
             "type": "message",
             "id": "user-1",
+            "timestamp": "2026-05-17T00:00:00.000Z",
             "message": {
                 "role": "user",
                 "timestamp": "2026-05-17T00:00:01.000Z",


### PR DESCRIPTION
## Summary
- Exclude Claude Code tool-result `type: "user"` events from `metadata.first_message_timestamp` selection.
- Prefer nested `payload.timestamp` / `message.timestamp` over event envelope timestamps when both exist.
- Add regression coverage for the two Codex review comments on #4.

## Why
The automated review on #4 caught two timestamp edge cases after merge:
- Claude Code tool-result events are encoded as `type: "user"`, but convert to `role: "tool"`, so they should not be treated as user-message timestamps.
- Pi/OpenClaw events may contain both an envelope timestamp and nested `message.timestamp`; the nested timestamp is the per-message value promised by the metadata docs.

Follow-up to #4.

## Validation
- `uv run pytest tests/test_converter.py` -> 34 passed
- `uv run pytest tests/test_converter.py tests/test_loader.py tests/test_trace_readme.py` -> 59 passed
- `uv run pytest` -> 344 passed, 21 skipped
- `uv run ruff check .` -> passed
- `git diff --check` -> passed
- `uv build` -> built sdist and wheel for 0.1.3
- `uv pip check` -> all installed packages compatible
- `uv run python -m compileall -q src tests` -> passed
- Example trace smoke for `examples/example_claude_code.jsonl`, `examples/example_codex_session.jsonl`, and `examples/example_pi_session.jsonl` -> passed
- Current HF Datasets source-path integration smoke using `datasets.packaged_modules.json.Json(features=AGENT_TRACES_FEATURES)` -> passed for Claude tool-result, Pi nested timestamp, and OpenClaw nested timestamp cases
- Live smoke: `load_traces("cfahlgren1/openclaw-test")` returns `metadata.first_message_timestamp == "2026-02-16T23:40:43.795000Z"`, confirming the nested OpenClaw message timestamp wins.