### PR TITLE
Add Factory droid trace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,9 @@ from teich import (
 )
 ```
 
-`detect_trace_type(events)` returns `codex`, `claude_code`, `pi`, `hermes`, or `external_agent` for supported parsed trace events, and `None` for ordinary JSON rows.
+`detect_trace_type(events)` returns `codex`, `claude_code`, `droid`, `pi`, `hermes`, or `external_agent` for supported parsed trace events, and `None` for ordinary JSON rows.
+
+Factory `droid` CLI sessions are supported as a conversion-only source: point `prepare_data()` or `load_traces()` at session JSONL files from `~/.factory/sessions/...` and Teich converts them directly, reading the adjacent `<session-id>.settings.json` sidecar for model and token usage metadata.
 
 `README.md` is the package readme used for PyPI, so these examples are the canonical public package docs.
 

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -1545,6 +1545,21 @@ def _convert_claude_code_trace_to_training_example(
     )
 
 
+def _droid_settings_path(trace_file: Path) -> Path:
+    return trace_file.with_suffix(".settings.json")
+
+
+def _load_droid_settings_sidecar(trace_file: Path) -> dict[str, Any]:
+    settings_path = _droid_settings_path(trace_file)
+    if not settings_path.exists():
+        return {}
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return settings if isinstance(settings, dict) else {}
+
+
 def _convert_droid_trace_to_training_example(
     trace_file: Path,
     events: list[dict[str, Any]],
@@ -1660,16 +1675,26 @@ def _convert_droid_trace_to_training_example(
             ),
             "",
         )
+    settings = _load_droid_settings_sidecar(trace_file)
+    model = settings.get("model")
+    provider_lock = settings.get("providerLock")
     metadata: dict[str, Any] = {
         "source_file": trace_file.name,
         "session_id": session_id or trace_file.stem,
         "trace_type": "droid",
-        "model_provider": "factory",
-        "model": None,
+        "model_provider": provider_lock if isinstance(provider_lock, str) and provider_lock.strip() else "factory",
+        "model": model if isinstance(model, str) and model.strip() else None,
         "cwd": cwd,
         "title": title,
         "turn_count": sum(1 for message in messages if message.get("role") == "user"),
     }
+    usage = settings.get("tokenUsage")
+    if isinstance(usage, dict) and usage:
+        metadata["usage"] = usage
+    for settings_key, metadata_key in (("reasoningEffort", "reasoning_effort"), ("autonomyLevel", "autonomy_level")):
+        value = settings.get(settings_key)
+        if isinstance(value, str) and value.strip():
+            metadata[metadata_key] = value.strip()
     return TrainingExample(
         source_file=trace_file,
         prompt=prompt,

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -1620,7 +1620,7 @@ def _convert_droid_trace_to_training_example(
                     )
                 continue
             content = _claude_text_from_content(content_blocks)
-            if content and not prompt:
+            if content and not prompt and payload.get("visibility") != "llm_only":
                 prompt = content
             if content:
                 messages.append({"role": "user", "content": content})

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -241,6 +241,136 @@ _CLAUDE_CODE_BUILTIN_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     },
 }
 
+_DROID_BUILTIN_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "Read": {
+        "description": "Read a file from the filesystem.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "offset": {"type": "number"},
+                "limit": {"type": "number"},
+                "image_quality": {"type": "string"},
+            },
+            "required": ["file_path"],
+            "additionalProperties": True,
+        },
+    },
+    "Edit": {
+        "description": "Replace a string in a file.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "old_str": {"type": "string"},
+                "new_str": {"type": "string"},
+            },
+            "required": ["file_path", "old_str", "new_str"],
+            "additionalProperties": True,
+        },
+    },
+    "Create": {
+        "description": "Create a new file with the given content.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "content": {"type": "string"},
+            },
+            "required": ["file_path", "content"],
+            "additionalProperties": True,
+        },
+    },
+    "Execute": {
+        "description": "Run a shell command.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+                "summary": {"type": "string"},
+                "riskLevel": {"type": "string"},
+                "riskLevelReason": {"type": "string"},
+                "timeout": {"type": "number"},
+                "fireAndForget": {"type": "boolean"},
+            },
+            "required": ["command"],
+            "additionalProperties": True,
+        },
+    },
+    "LS": {
+        "description": "List the contents of a directory.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "directory_path": {"type": "string"},
+            },
+            "required": ["directory_path"],
+            "additionalProperties": True,
+        },
+    },
+    "Glob": {
+        "description": "Find files matching glob patterns.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "patterns": {"type": "array", "items": {"type": "string"}},
+                "folder": {"type": "string"},
+            },
+            "required": ["patterns"],
+            "additionalProperties": True,
+        },
+    },
+    "Grep": {
+        "description": "Search file contents for a pattern.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pattern": {"type": "string"},
+                "path": {"type": "string"},
+                "output_mode": {"type": "string"},
+                "case_insensitive": {"type": "boolean"},
+                "fixed_string": {"type": "boolean"},
+                "head_limit": {"type": "number"},
+            },
+            "required": ["pattern"],
+            "additionalProperties": True,
+        },
+    },
+    "TodoWrite": {
+        "description": "Update the task list.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "todos": {"type": "string"},
+            },
+            "required": ["todos"],
+            "additionalProperties": True,
+        },
+    },
+    "FetchUrl": {
+        "description": "Fetch the contents of a URL.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string"},
+            },
+            "required": ["url"],
+            "additionalProperties": True,
+        },
+    },
+    "Skill": {
+        "description": "Invoke a skill.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "skill": {"type": "string"},
+            },
+            "required": ["skill"],
+            "additionalProperties": True,
+        },
+    },
+}
+
 
 @dataclass(slots=True)
 class TrainingExample:
@@ -1420,8 +1550,8 @@ def _convert_droid_trace_to_training_example(
     events: list[dict[str, Any]],
 ) -> TrainingExample:
     messages: list[dict[str, Any]] = []
-    tool_names: set[str] = set()
-    tool_schemas: dict[str, dict[str, Any]] = {}
+    tool_names: set[str] = set(_DROID_BUILTIN_TOOL_SCHEMAS)
+    tool_schemas: dict[str, dict[str, Any]] = deepcopy(_DROID_BUILTIN_TOOL_SCHEMAS)
     tool_argument_samples: dict[str, list[Any]] = {}
     tool_names_by_call_id: dict[str, str] = {}
     session_id: str | None = None

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -1415,6 +1415,140 @@ def _convert_claude_code_trace_to_training_example(
     )
 
 
+def _convert_droid_trace_to_training_example(
+    trace_file: Path,
+    events: list[dict[str, Any]],
+) -> TrainingExample:
+    messages: list[dict[str, Any]] = []
+    tool_names: set[str] = set()
+    tool_schemas: dict[str, dict[str, Any]] = {}
+    tool_argument_samples: dict[str, list[Any]] = {}
+    tool_names_by_call_id: dict[str, str] = {}
+    session_id: str | None = None
+    cwd: str | None = None
+    title: str | None = None
+    prompt = ""
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type == "session_start":
+            value = event.get("id")
+            if isinstance(value, str) and value.strip():
+                session_id = value.strip()
+            value = event.get("cwd")
+            if isinstance(value, str) and value.strip():
+                cwd = value.strip()
+            value = event.get("sessionTitle") or event.get("title")
+            if isinstance(value, str) and value.strip():
+                title = value.strip()
+            continue
+        if event_type != "message":
+            continue
+        payload = event.get("message")
+        if not isinstance(payload, dict):
+            continue
+        role = payload.get("role")
+        content_blocks = payload.get("content")
+
+        if role == "user":
+            if isinstance(content_blocks, list) and any(
+                isinstance(block, dict) and block.get("type") == "tool_result"
+                for block in content_blocks
+            ):
+                for block in content_blocks:
+                    if not isinstance(block, dict) or block.get("type") != "tool_result":
+                        continue
+                    tool_call_id = block.get("tool_use_id") or block.get("tool_call_id")
+                    if not isinstance(tool_call_id, str) or not tool_call_id:
+                        continue
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_call_id,
+                            "name": tool_names_by_call_id.get(tool_call_id, "unknown_tool"),
+                            "content": _claude_tool_result_text(block),
+                        }
+                    )
+                continue
+            content = _claude_text_from_content(content_blocks)
+            if content and not prompt:
+                prompt = content
+            if content:
+                messages.append({"role": "user", "content": content})
+            continue
+
+        if role == "assistant":
+            content = _claude_text_from_content(content_blocks)
+            message: dict[str, Any] = {"role": "assistant", "content": content}
+            reasoning_content = _claude_reasoning_from_content(content_blocks)
+            if reasoning_content:
+                message["reasoning_content"] = reasoning_content
+            tool_calls: list[dict[str, Any]] = []
+            if isinstance(content_blocks, list):
+                for block in content_blocks:
+                    if not isinstance(block, dict) or block.get("type") != "tool_use":
+                        continue
+                    tool_call_id = block.get("id")
+                    tool_name = block.get("name")
+                    if not isinstance(tool_call_id, str) or not isinstance(tool_name, str):
+                        continue
+                    if not tool_call_id or not tool_name:
+                        continue
+                    arguments = _normalize_json_like_value(block.get("input") or {})
+                    tool_names.add(tool_name)
+                    tool_names_by_call_id[tool_call_id] = tool_name
+                    tool_argument_samples.setdefault(tool_name, []).append(arguments)
+                    tool_calls.append(
+                        {
+                            "id": tool_call_id,
+                            "type": "function",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": arguments,
+                            },
+                        }
+                    )
+            if tool_calls:
+                message["tool_calls"] = tool_calls
+            if content or reasoning_content or tool_calls:
+                _append_or_merge_assistant_message(messages, message)
+
+    tools = _build_tools_from_snapshots_and_calls(
+        tool_names,
+        tool_schemas,
+        tool_argument_samples,
+        {},
+    )
+    if not prompt:
+        prompt = next(
+            (
+                message.get("content", "")
+                for message in messages
+                if message.get("role") == "user" and isinstance(message.get("content"), str)
+            ),
+            "",
+        )
+    metadata: dict[str, Any] = {
+        "source_file": trace_file.name,
+        "session_id": session_id or trace_file.stem,
+        "trace_type": "droid",
+        "model_provider": "factory",
+        "model": None,
+        "cwd": cwd,
+        "title": title,
+        "turn_count": sum(1 for message in messages if message.get("role") == "user"),
+    }
+    return TrainingExample(
+        source_file=trace_file,
+        prompt=prompt,
+        messages=messages,
+        tools=tools,
+        metadata=metadata,
+    )
+
+
 def _convert_hermes_trace_to_training_example(
     trace_file: Path,
     events: list[dict[str, Any]],
@@ -2328,6 +2462,8 @@ def convert_trace_to_training_example(trace_file: Path) -> TrainingExample:
     trace_type = _detect_trace_type(events)
     if trace_type == "claude_code":
         return _convert_claude_code_trace_to_training_example(trace_file, events)
+    if trace_type == "droid":
+        return _convert_droid_trace_to_training_example(trace_file, events)
     if trace_type == "hermes":
         return _convert_hermes_trace_to_training_example(trace_file, events)
     if trace_type == "external_agent":
@@ -2359,6 +2495,8 @@ def _convert_jsonl_file_to_training_rows(jsonl_file: Path) -> list[dict[str, Any
     trace_type = _detect_trace_type(rows)
     if trace_type == "claude_code":
         return [_convert_claude_code_trace_to_training_example(jsonl_file, rows).to_dict()]
+    if trace_type == "droid":
+        return [_convert_droid_trace_to_training_example(jsonl_file, rows).to_dict()]
     if trace_type == "hermes":
         if all(_is_hermes_trace_row(row) for row in rows):
             return [

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -12,7 +12,7 @@ _INLINE_THINKING_BLOCK_PATTERN = re.compile(r"<(think|thinking)>(.*?)</\1>", re.
 PI_SYSTEM_PROMPT_CUSTOM_TYPE = "teich-system-prompt"
 TEICH_AVAILABLE_TOOLS_CUSTOM_TYPE = "teich-available-tools"
 TEICH_TRACE_CONTEXT_ITEM_TYPE = "teich_context"
-TraceType = Literal["claude_code", "codex", "external_agent", "hermes", "pi"]
+TraceType = Literal["claude_code", "codex", "droid", "external_agent", "hermes", "pi"]
 
 _CLAUDE_CODE_BUILTIN_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "Task": {
@@ -978,6 +978,8 @@ def _detect_trace_type(events: list[Any], default: TraceType | None = "codex") -
             return "claude_code"
         if event_type in {"session_meta", "turn_context", "response_item", "event_msg"}:
             return "codex"
+        if event_type == "session_start" and isinstance(event.get("cwd"), str) and event.get("version") is not None:
+            return "droid"
         if event_type in {
             "session",
             "message",

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -466,6 +466,19 @@ def _is_claude_code_user_message(event: dict[str, Any]) -> bool:
     )
 
 
+def _is_droid_user_message(event: dict[str, Any]) -> bool:
+    if event.get("type") != "message":
+        return False
+    message = event.get("message")
+    if not isinstance(message, dict) or message.get("role") != "user":
+        return False
+    content = message.get("content")
+    return not (
+        isinstance(content, list)
+        and any(isinstance(block, dict) and block.get("type") == "tool_result" for block in content)
+    )
+
+
 def _first_text_block(content_blocks: Any) -> str:
     if isinstance(content_blocks, str):
         return _unwrap_teich_prompt_file(content_blocks).strip()
@@ -1681,6 +1694,7 @@ def _convert_droid_trace_to_training_example(
     cwd: str | None = None
     title: str | None = None
     prompt = ""
+    first_message_timestamp = _first_message_timestamp_from_events(events, _is_droid_user_message)
 
     for event in events:
         if not isinstance(event, dict):
@@ -1798,6 +1812,7 @@ def _convert_droid_trace_to_training_example(
         "title": title,
         "turn_count": sum(1 for message in messages if message.get("role") == "user"),
     }
+    _add_first_message_timestamp(metadata, first_message_timestamp)
     usage = settings.get("tokenUsage")
     if isinstance(usage, dict) and usage:
         metadata["usage"] = usage

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -1594,6 +1594,8 @@ def _convert_droid_trace_to_training_example(
         payload = event.get("message")
         if not isinstance(payload, dict):
             continue
+        if payload.get("visibility") == "user_only":
+            continue
         role = payload.get("role")
         content_blocks = payload.get("content")
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -586,6 +586,66 @@ def test_convert_droid_trace(tmp_path: Path):
     assert "LS" in tool_names
 
 
+def test_convert_droid_trace_reads_settings_sidecar(tmp_path: Path):
+    trace_file = tmp_path / "droid-settings.jsonl"
+    events = [
+        {"type": "session_start", "id": "droid-session", "version": 2, "cwd": "/workspace/project"},
+        {
+            "type": "message",
+            "id": "message-1",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Say hi"}]},
+        },
+        {
+            "type": "message",
+            "id": "message-2",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "Hi!"}]},
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+    settings = {
+        "model": "custom:Kimi-K2.6-[HF-Router]-0",
+        "reasoningEffort": "high",
+        "autonomyLevel": "medium",
+        "providerLock": "generic-chat-completion-api",
+        "tokenUsage": {
+            "inputTokens": 202809,
+            "outputTokens": 29390,
+            "cacheCreationTokens": 0,
+            "cacheReadTokens": 4843520,
+            "thinkingTokens": 0,
+            "factoryCredits": 0,
+        },
+    }
+    (tmp_path / "droid-settings.settings.json").write_text(json.dumps(settings), encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    assert example.metadata["model"] == "custom:Kimi-K2.6-[HF-Router]-0"
+    assert example.metadata["model_provider"] == "generic-chat-completion-api"
+    assert example.metadata["usage"] == settings["tokenUsage"]
+    assert example.metadata["reasoning_effort"] == "high"
+    assert example.metadata["autonomy_level"] == "medium"
+
+
+def test_convert_droid_trace_without_settings_sidecar(tmp_path: Path):
+    trace_file = tmp_path / "droid-no-settings.jsonl"
+    events = [
+        {"type": "session_start", "id": "droid-session", "version": 2, "cwd": "/workspace/project"},
+        {
+            "type": "message",
+            "id": "message-1",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Say hi"}]},
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    assert example.metadata["model"] is None
+    assert example.metadata["model_provider"] == "factory"
+    assert "usage" not in example.metadata
+
+
 def test_convert_droid_trace_includes_builtin_tools(tmp_path: Path):
     trace_file = tmp_path / "droid-tools.jsonl"
     events = [

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -586,6 +586,34 @@ def test_convert_droid_trace(tmp_path: Path):
     assert "LS" in tool_names
 
 
+def test_convert_droid_trace_includes_builtin_tools(tmp_path: Path):
+    trace_file = tmp_path / "droid-tools.jsonl"
+    events = [
+        {"type": "session_start", "id": "droid-session", "version": 2, "cwd": "/workspace/project"},
+        {
+            "type": "message",
+            "id": "message-1",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Say hi"}]},
+        },
+        {
+            "type": "message",
+            "id": "message-2",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "Hi!"}]},
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    tool_names = {tool["function"]["name"] for tool in example.tools}
+    assert {"Read", "Edit", "Create", "Execute", "LS", "Glob", "Grep", "TodoWrite", "FetchUrl", "Skill"}.issubset(tool_names)
+    read_tool = next(tool for tool in example.tools if tool["function"]["name"] == "Read")
+    assert read_tool["function"]["parameters"]["properties"]["file_path"]["type"] == "string"
+    assert read_tool["function"]["parameters"]["required"] == ["file_path"]
+    glob_tool = next(tool for tool in example.tools if tool["function"]["name"] == "Glob")
+    assert glob_tool["function"]["parameters"]["properties"]["patterns"]["type"] == "array"
+
+
 def test_convert_claude_code_keeps_init_tools_without_tool_calls(tmp_path: Path):
     trace_file = tmp_path / "claude-no-tools.jsonl"
     events = [

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -646,6 +646,39 @@ def test_convert_droid_trace_without_settings_sidecar(tmp_path: Path):
     assert "usage" not in example.metadata
 
 
+def test_convert_droid_trace_prefers_user_authored_prompt(tmp_path: Path):
+    trace_file = tmp_path / "droid-prompt.jsonl"
+    events = [
+        {"type": "session_start", "id": "droid-session", "version": 2, "cwd": "/workspace/project"},
+        {
+            "type": "message",
+            "id": "message-1",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "<system-reminder>Injected environment context.</system-reminder>"}],
+                "visibility": "llm_only",
+            },
+        },
+        {
+            "type": "message",
+            "id": "message-2",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Summarize the README"}]},
+        },
+        {
+            "type": "message",
+            "id": "message-3",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "Done."}]},
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    assert example.prompt == "Summarize the README"
+    assert example.messages[0]["content"].startswith("<system-reminder>")
+    assert example.messages[1] == {"role": "user", "content": "Summarize the README"}
+
+
 def test_convert_droid_trace_skips_user_only_and_state_events(tmp_path: Path):
     trace_file = tmp_path / "droid-edge-cases.jsonl"
     events = [

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -487,6 +487,105 @@ def test_convert_claude_code_stream_json_trace(tmp_path: Path):
     assert todo_tool["function"]["parameters"]["properties"]["todos"]["type"] == "array"
 
 
+def test_convert_droid_trace(tmp_path: Path):
+    trace_file = tmp_path / "droid.jsonl"
+    events = [
+        {
+            "type": "session_start",
+            "id": "droid-session",
+            "title": "inspect the project",
+            "sessionTitle": "Inspect project files",
+            "owner": "caleb",
+            "version": 2,
+            "cwd": "/workspace/project",
+        },
+        {
+            "type": "message",
+            "id": "message-1",
+            "timestamp": "2026-06-02T18:55:30.274Z",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "Inspect the project"}],
+            },
+            "parentId": None,
+        },
+        {
+            "type": "message",
+            "id": "message-2",
+            "timestamp": "2026-06-02T18:55:35.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "I should list the files first.",
+                        "signature": "reasoning_content",
+                        "signatureProvider": "generic-chat-completion-api",
+                        "durationMs": 1200,
+                    },
+                    {"type": "text", "text": "I'll list the files."},
+                    {"type": "tool_use", "id": "LS_0", "name": "LS", "input": {"directory_path": "/workspace/project"}},
+                ],
+                "chatCompletionReasoningField": "reasoning_content",
+                "chatCompletionReasoningContent": "I should list the files first.",
+            },
+            "parentId": "message-1",
+        },
+        {
+            "type": "message",
+            "id": "message-3",
+            "timestamp": "2026-06-02T18:55:36.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "LS_0", "is_error": False, "content": "README.md\nsrc"},
+                ],
+            },
+            "parentId": "message-2",
+        },
+        {
+            "type": "message",
+            "id": "message-4",
+            "timestamp": "2026-06-02T18:55:40.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "The project contains README.md and src."}],
+            },
+            "parentId": "message-3",
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    assert example.metadata["trace_type"] == "droid"
+    assert example.metadata["session_id"] == "droid-session"
+    assert example.metadata["cwd"] == "/workspace/project"
+    assert example.metadata["title"] == "Inspect project files"
+    assert example.metadata["turn_count"] == 1
+    assert example.prompt == "Inspect the project"
+    assert example.messages[0] == {"role": "user", "content": "Inspect the project"}
+    assert example.messages[1]["role"] == "assistant"
+    assert example.messages[1]["content"] == "I'll list the files."
+    assert example.messages[1]["reasoning_content"] == "I should list the files first."
+    assert example.messages[1]["tool_calls"] == [
+        {
+            "id": "LS_0",
+            "type": "function",
+            "function": {"name": "LS", "arguments": {"directory_path": "/workspace/project"}},
+        }
+    ]
+    assert example.messages[2] == {
+        "role": "tool",
+        "tool_call_id": "LS_0",
+        "name": "LS",
+        "content": "README.md\nsrc",
+    }
+    assert example.messages[3] == {"role": "assistant", "content": "The project contains README.md and src."}
+    tool_names = {tool["function"]["name"] for tool in example.tools}
+    assert "LS" in tool_names
+
+
 def test_convert_claude_code_keeps_init_tools_without_tool_calls(tmp_path: Path):
     trace_file = tmp_path / "claude-no-tools.jsonl"
     events = [

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -722,6 +722,7 @@ def test_convert_droid_trace(tmp_path: Path):
     assert example.metadata["cwd"] == "/workspace/project"
     assert example.metadata["title"] == "Inspect project files"
     assert example.metadata["turn_count"] == 1
+    assert example.metadata["first_message_timestamp"] == "2026-06-02T18:55:30.274Z"
     assert example.prompt == "Inspect the project"
     assert example.messages[0] == {"role": "user", "content": "Inspect the project"}
     assert example.messages[1]["role"] == "assistant"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -646,6 +646,59 @@ def test_convert_droid_trace_without_settings_sidecar(tmp_path: Path):
     assert "usage" not in example.metadata
 
 
+def test_convert_droid_trace_skips_user_only_and_state_events(tmp_path: Path):
+    trace_file = tmp_path / "droid-edge-cases.jsonl"
+    events = [
+        {"type": "session_start", "id": "droid-session", "version": 2, "cwd": "/workspace/project"},
+        {
+            "type": "message",
+            "id": "message-1",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "No active subscription found."}],
+                "visibility": "user_only",
+            },
+        },
+        {
+            "type": "message",
+            "id": "message-2",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this screenshot"},
+                    {"type": "image", "source": {"type": "base64", "data": "abc123"}},
+                ],
+                "visibility": "llm_only",
+            },
+        },
+        {
+            "type": "todo_state",
+            "id": "todo-1",
+            "todos": {"todos": "1. [in_progress] Describe the screenshot"},
+            "messageIndex": 1,
+        },
+        {
+            "type": "compaction_state",
+            "id": "compaction-1",
+            "summaryText": "USER: earlier conversation summary",
+        },
+        {
+            "type": "message",
+            "id": "message-3",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "It shows a terminal."}]},
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    assert example.prompt == "Describe this screenshot"
+    assert example.messages == [
+        {"role": "user", "content": "Describe this screenshot"},
+        {"role": "assistant", "content": "It shows a terminal."},
+    ]
+
+
 def test_convert_droid_trace_includes_builtin_tools(tmp_path: Path):
     trace_file = tmp_path / "droid-tools.jsonl"
     events = [

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -23,6 +23,13 @@ def test_detect_trace_type_returns_known_trace_type():
             "hermes",
         ),
         ([{"type": "external_session_meta", "payload": {"source": "custom-agent"}}], "external_agent"),
+        (
+            [
+                {"type": "session_start", "id": "droid-session", "version": 2, "cwd": "/workspace/project"},
+                {"type": "message", "id": "message-1", "message": {"role": "user", "content": [{"type": "text", "text": "hello"}]}},
+            ],
+            "droid",
+        ),
     ]
 
     for events, expected_trace_type in cases:


### PR DESCRIPTION
Adds Factory [droid](https://factory.ai) CLI sessions as a supported trace source. Session JSONL files from `~/.factory/sessions/...` are now detected and converted directly into training examples, alongside the existing codex / claude_code / pi / openclaw / hermes sources.

### Detection

A droid trace is identified by its first event: `type == "session_start"` with a string `cwd` and a non-null `version`. The check sits after codex and before pi in `_detect_trace_type`, so there is no collision with the other formats (openclaw uses `type == "session"`, codex uses `session_meta`).
