### PR TITLE
Add local session extract flow with anonymization and Hugging Face upload

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -2,7 +2,7 @@
 
 Teich documentation now lives in focused pages under [`docs/`](docs/index.md).
 
-- [Generation](docs/generation.md): create new Codex, Pi, Claude Code, Hermes, or chat datasets.
+- [Generation](docs/generation.md): create new Codex, Pi, Claude Code, Hermes, or chat datasets, or extract existing local sessions with `teich extract`.
 - [Teich Studio](docs/studio.md): configure projects, manage prompts, run batches, and save interactive sessions from a browser.
 - [Preparing Data](docs/prepare-data.md): load local files, folders, Hugging Face datasets, `datasets.Dataset` objects, and source mixes.
 - [Training](docs/training.md): use Teich with TRL / Unsloth and apply response-only labels with `mask_data()`.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Teich writes raw traces, converted training rows, sandbox snapshots, and a datas
 
 More detail: [Generation](docs/generation.md).
 
+## Quickstart: Extract Local Sessions
+
+If you already have local agent sessions, Teich can stage them as an anonymized dataset in one command:
+
+```bash
+teich extract claude --model fable-5
+```
+
+`extract` supports `claude`, `codex`, `pi`, and `hermes`. It writes anonymized traces to `data/` by default, generates a dataset `README.md`, and then asks whether to upload the folder to Hugging Face. Use `--out` / `--output` to choose another folder.
+
 ## What Teich Supports
 
 | Use case | Start here |
@@ -146,6 +156,9 @@ teich generate -c config.yaml
 
 # Resume an interrupted batch
 teich generate -c config.yaml --resume
+
+# Extract, anonymize, and stage local Claude Code traces
+teich extract claude --model fable-5 --out data
 
 # Launch the local browser UI
 teich studio

--- a/docs/generation.md
+++ b/docs/generation.md
@@ -6,6 +6,8 @@ Use generation when you want Teich to create source data for you. If you already
 
 If you prefer configuring prompts and steering sessions in a browser, use [Teich Studio](studio.md). It writes the same project files and output artifacts as the CLI.
 
+If you already have local agent sessions from Claude Code, Codex, Pi, or Hermes, use `teich extract` to stage them as an anonymized dataset without running a new generation batch.
+
 ## Create a Project
 
 ```bash
@@ -28,6 +30,35 @@ teich generate -c config.yaml --resume
 ```
 
 Teich scans completed output rows and skips prompts that already converted into training examples. Failed or interrupted agent traces are moved to `failures/` and are not treated as completed data.
+
+## Extract Local Sessions
+
+Extract local sessions, anonymize them, generate a dataset README, and optionally upload the staged folder to Hugging Face:
+
+```bash
+teich extract claude --model fable-5
+```
+
+Supported harnesses:
+
+```bash
+teich extract claude
+teich extract codex
+teich extract pi
+teich extract hermes
+```
+
+By default, extracted datasets are written to `data/` under the current directory. Use `--out` or `--output` to choose a different folder:
+
+```bash
+teich extract codex --model gpt-5-codex --out codex-data
+```
+
+`--model` filters by provider model metadata, not by arbitrary prompt text. This keeps traces that actually ran with matching model identifiers such as `claude-fable-5` and excludes traces that only mention the model name in conversation text.
+
+After extraction, Teich automatically scrubs API keys, emails, and home-directory usernames while preserving embedded media payloads for conversation context. It then prints the replacement counts and asks whether to upload to Hugging Face. If you choose upload, Teich asks for a dataset repo id and uses `HF_TOKEN`, `HUGGINGFACE_HUB_TOKEN`, or `TEICH_HF_TOKEN`; if none are set, it prompts for `HF_TOKEN`.
+
+Important: anonymization is a best-effort safety pass, not a guarantee. Review the staged data yourself before uploading or publishing it, and remove anything you would not want released.
 
 ## Browser UI
 
@@ -103,6 +134,8 @@ Provider outputs:
 - `claude-code`: native Claude Code transcript JSONL copied from `.claude/projects/...`, workspace snapshots in `sandbox/`, and a dataset `README.md`
 - `hermes`: one Teich external trace JSONL per Hermes `state.db` session, including delegated subagent sessions as separate files linked by `parent_session_id`
 - `chat`: text-only JSONL training rows in `output/` and a dataset `README.md`
+
+`teich extract` writes the same trace shapes to `data/` by default, but it operates on existing local session stores and anonymizes the staged output in place before the upload prompt.
 
 Uploaded Hugging Face dataset artifacts include:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,12 @@ Need new data:
 teich init -> edit prompts.jsonl/config.yaml -> teich generate -> prepare_data()
 ```
 
+Already have local agent sessions:
+
+```text
+teich extract claude --model fable-5 -> optional HF upload -> prepare_data()
+```
+
 Prefer a browser:
 
 ```text

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -8,11 +8,19 @@ This page describes how Teich moves from raw data to trainer labels.
 flowchart TD
     A["Raw source<br/>HF repo, local traces, Dataset, source mix, or prompts"] --> B{"Need generation?"}
     B -->|"yes"| C["teich generate"]
+    B -->|"existing local sessions"| X["teich extract"]
     B -->|"no"| D["prepare_data"]
     C --> C1["Run provider<br/>codex, pi, claude-code, hermes, or chat"]
     C1 --> C2["Write raw/native traces or structured chat rows"]
     C2 --> C3["Write dataset README + tool snapshots"]
     C3 --> D
+    X --> X1["Copy local sessions<br/>claude, codex, pi, or hermes"]
+    X1 --> X2["Filter by --model metadata when requested"]
+    X2 --> X3["Anonymize staged data + write README"]
+    X3 --> X4{"upload to Hugging Face?"}
+    X4 -->|"yes"| X5["Upload JSONL + README"]
+    X4 -->|"no"| D
+    X5 --> D
     D --> E["Resolve and load sources"]
     E --> F["Convert traces to messages + tools"]
     F --> G["Render tokenizer chat template"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "teich"
-version = "0.1.7"
+version = "0.1.8"
 description = "Turn coding agent traces into auditable supervised fine-tuning data"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/teich/__init__.py
+++ b/src/teich/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 from .audit import SFTAuditReport, audit_sft_dataset
 from .config import Config, load_config

--- a/src/teich/anonymize.py
+++ b/src/teich/anonymize.py
@@ -1,0 +1,410 @@
+"""Deterministic anonymization for exported traces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import hashlib
+import json
+import re
+import shutil
+import string
+from typing import Any
+
+
+TEXT_EXTENSIONS = {
+    ".jsonl",
+    ".json",
+    ".md",
+    ".txt",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".log",
+}
+
+
+@dataclass
+class AnonymizeFileReport:
+    path: Path
+    output_path: Path
+    replacements: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def changed(self) -> bool:
+        return any(count > 0 for count in self.replacements.values())
+
+
+@dataclass
+class AnonymizeReport:
+    input_path: Path
+    output_path: Path
+    files: list[AnonymizeFileReport] = field(default_factory=list)
+
+    @property
+    def files_changed(self) -> int:
+        return sum(1 for item in self.files if item.changed)
+
+    @property
+    def totals(self) -> dict[str, int]:
+        totals: dict[str, int] = {}
+        for item in self.files:
+            for key, count in item.replacements.items():
+                totals[key] = totals.get(key, 0) + count
+        return totals
+
+
+def anonymize_path(input_path: Path, output_path: Path, *, in_place: bool = False) -> AnonymizeReport:
+    """Anonymize trace files under input_path."""
+    input_path = input_path.expanduser()
+    output_path = output_path.expanduser()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input path not found: {input_path}")
+    if in_place:
+        output_path = input_path
+    elif input_path.is_dir() and _path_contains(input_path, output_path):
+        raise ValueError("Output path must not be inside the input directory")
+
+    report = AnonymizeReport(input_path=input_path, output_path=output_path)
+    if input_path.is_file():
+        destination = output_path / input_path.name if output_path.exists() and output_path.is_dir() else output_path
+        file_report = _anonymize_file(input_path, destination)
+        report.files.append(file_report)
+        return report
+
+    for source_file in sorted(path for path in input_path.rglob("*") if path.is_file()):
+        relative_path = source_file.relative_to(input_path)
+        destination = source_file if in_place else output_path / relative_path
+        file_report = _anonymize_file(source_file, destination)
+        report.files.append(file_report)
+    return report
+
+
+def _path_contains(parent: Path, child: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _anonymize_file(source: Path, destination: Path) -> AnonymizeFileReport:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.suffix.lower() not in TEXT_EXTENSIONS:
+        if source.resolve() != destination.resolve():
+            shutil.copy2(source, destination)
+        return AnonymizeFileReport(path=source, output_path=destination)
+
+    anonymizer = TraceAnonymizer()
+    if source.suffix.lower() == ".jsonl":
+        text = _anonymize_jsonl_text(source, anonymizer)
+    else:
+        try:
+            original = source.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            if source.resolve() != destination.resolve():
+                shutil.copy2(source, destination)
+            return AnonymizeFileReport(path=source, output_path=destination)
+        text = anonymizer.anonymize_text(original)
+
+    destination.write_text(text, encoding="utf-8")
+    return AnonymizeFileReport(
+        path=source,
+        output_path=destination,
+        replacements={key: value for key, value in anonymizer.counts.items() if value},
+    )
+
+
+def _anonymize_jsonl_text(source: Path, anonymizer: "TraceAnonymizer") -> str:
+    rows: list[str] = []
+    try:
+        with source.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    rows.append(raw_line)
+                    continue
+                row = json.loads(line)
+                redacted_row = anonymizer.anonymize_value(row)
+                rows.append(json.dumps(redacted_row, ensure_ascii=False) + "\n")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return anonymizer.anonymize_text(source.read_text(encoding="utf-8", errors="replace"))
+    return "".join(rows)
+
+
+class TraceAnonymizer:
+    """Stateful per-trace anonymizer with consistent replacement maps."""
+
+    _email_pattern = re.compile(
+        r"(?<![A-Za-z0-9._%+-])([A-Za-z0-9][A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]*@[A-Za-z0-9.-]+\.[A-Za-z]{2,})(?![A-Za-z0-9._%+-])"
+    )
+    _home_path_pattern = re.compile(
+        r"(?P<prefix>(?:[A-Za-z]:)?[\\/]+(?:home|Users)[\\/]+)(?P<username>[^\\/:\s\"'<>|]+)",
+        re.IGNORECASE,
+    )
+    _encoded_home_path_pattern = re.compile(
+        r"(?<![A-Za-z0-9])(?P<prefix>-(?:home|Users)-)(?P<username>[A-Za-z0-9._]+)(?=$|[-\\/\s\"'])",
+        re.IGNORECASE,
+    )
+    _api_key_patterns = [
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>sk-or-v1-)(?P<body>[A-Za-z0-9_-]{16,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>sk-ant-api03-)(?P<body>[A-Za-z0-9_-]{16,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>sk-proj-)(?P<body>[A-Za-z0-9_-]{16,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>sk-)(?!or-v1-|ant-api03-|proj-)(?P<body>[A-Za-z0-9_-]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>hf_)(?P<body>[A-Za-z0-9]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>gsk_)(?P<body>[A-Za-z0-9]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>github_pat_)(?P<body>[A-Za-z0-9_]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>gh[pousr]_)(?P<body>[A-Za-z0-9_]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>glpat-)(?P<body>[A-Za-z0-9_-]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>xox[baprs]-)(?P<body>[A-Za-z0-9-]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>AIza)(?P<body>[A-Za-z0-9_-]{20,})"),
+        re.compile(r"(?<![A-Za-z0-9])(?P<prefix>ctx7sk-)(?P<body>[A-Za-z0-9-]{20,})"),
+    ]
+    _jwt_pattern = re.compile(
+        r"(?<![A-Za-z0-9_-])(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})(?![A-Za-z0-9_-])"
+    )
+    _bearer_pattern = re.compile(r"(?i)(\bBearer\s+)([A-Za-z0-9._~+/=-]{24,})")
+    _generic_secret_pattern = re.compile(
+        r"(?i)(\b(?:[A-Za-z0-9]+[_-])*(?:api[_-]?key|token|secret|password)\b[\"']?[^\S\r\n]*[:=][^\S\r\n]*[\"']?)([A-Za-z0-9_~+/=-]{24,})"
+    )
+    _non_person_usernames = {
+        "all users",
+        "default",
+        "defaultuser0",
+        "public",
+        "shared",
+    }
+    _systemd_unit_suffixes = (
+        ".automount",
+        ".device",
+        ".mount",
+        ".path",
+        ".scope",
+        ".service",
+        ".slice",
+        ".socket",
+        ".swap",
+        ".target",
+        ".timer",
+    )
+    _known_git_remote_addresses = {
+        "git@github.com",
+        "git@ssh.github.com",
+        "git@gitlab.com",
+        "git@bitbucket.org",
+    }
+
+    def __init__(self) -> None:
+        self.counts = {"email": 0, "username": 0, "api_key": 0}
+        self._email_map: dict[str, str] = {}
+        self._username_map: dict[str, str] = {}
+        self._api_key_map: dict[str, str] = {}
+        self._api_replacements: set[str] = set()
+
+    def anonymize_value(self, value: Any) -> Any:
+        if isinstance(value, str):
+            return self.anonymize_text(value)
+        if isinstance(value, list):
+            return [self.anonymize_value(item) for item in value]
+        if isinstance(value, dict):
+            return self._anonymize_mapping(value)
+        return value
+
+    def _anonymize_mapping(self, value: dict[Any, Any]) -> dict[Any, Any]:
+        should_preserve_base64_data = self._looks_like_base64_media_source(value)
+        redacted: dict[Any, Any] = {}
+        for key, item in value.items():
+            redacted_key = self.anonymize_value(key)
+            if (
+                should_preserve_base64_data
+                and key == "data"
+                and isinstance(item, str)
+                and self._looks_like_base64_blob(item)
+            ):
+                redacted[redacted_key] = item
+            else:
+                redacted[redacted_key] = self.anonymize_value(item)
+        return redacted
+
+    @staticmethod
+    def _looks_like_base64_media_source(value: dict[Any, Any]) -> bool:
+        source_type = value.get("type")
+        media_type = value.get("media_type") or value.get("mime_type")
+        return (
+            isinstance(source_type, str)
+            and source_type.lower() == "base64"
+            and isinstance(value.get("data"), str)
+        ) or (
+            isinstance(media_type, str)
+            and media_type.lower().startswith(("image/", "audio/", "video/"))
+            and isinstance(value.get("data"), str)
+        )
+
+    @staticmethod
+    def _looks_like_base64_blob(value: str) -> bool:
+        if len(value) < 256:
+            return False
+        return re.fullmatch(r"[A-Za-z0-9+/=\s]+", value) is not None
+
+    def anonymize_text(self, text: str) -> str:
+        text = self._replace_emails(text)
+        text = self._replace_usernames_in_paths(text)
+        text = self._replace_encoded_home_usernames(text)
+        text = self._replace_known_unix_owner_group_usernames(text)
+        text = self._replace_api_keys(text)
+        return text
+
+    def _replace_emails(self, text: str) -> str:
+        def replace(match: re.Match[str]) -> str:
+            original = match.group(1)
+            if self._looks_like_non_email_reference(original, match, text):
+                return original
+            key = original.lower()
+            if key not in self._email_map:
+                local_part = original.split("@", maxsplit=1)[0]
+                username = self._map_username(local_part)
+                self._email_map[key] = f"{username}@example.com"
+            self.counts["email"] += 1
+            return self._email_map[key]
+
+        return self._email_pattern.sub(replace, text)
+
+    def _looks_like_non_email_reference(self, value: str, match: re.Match[str], text: str) -> bool:
+        if "`" in value:
+            return True
+        if "/" in value or "\\" in value:
+            return True
+        if self._looks_like_uri_userinfo(match, text):
+            return True
+        lowered = value.lower()
+        if lowered.endswith(self._systemd_unit_suffixes):
+            return True
+        if lowered in self._known_git_remote_addresses:
+            return True
+        return False
+
+    @staticmethod
+    def _looks_like_uri_userinfo(match: re.Match[str], text: str) -> bool:
+        start = match.start()
+        segment_start = max(text.rfind(boundary, 0, start) for boundary in " \t\r\n\"'<>")
+        prefix_segment = text[segment_start + 1:start]
+        scheme_separator = prefix_segment.rfind("://")
+        if scheme_separator == -1:
+            return False
+        scheme = prefix_segment[:scheme_separator].rsplit("/", maxsplit=1)[-1]
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9+.-]*", scheme):
+            return False
+        authority_prefix = prefix_segment[scheme_separator + 3:]
+        return not any(separator in authority_prefix for separator in "/\\?#")
+
+    def _replace_usernames_in_paths(self, text: str) -> str:
+        def replace(match: re.Match[str]) -> str:
+            username = match.group("username")
+            if username.lower() in self._non_person_usernames:
+                return match.group(0)
+            self.counts["username"] += 1
+            return f"{match.group('prefix')}{self._map_username(username)}"
+
+        return self._home_path_pattern.sub(replace, text)
+
+    def _replace_encoded_home_usernames(self, text: str) -> str:
+        def replace(match: re.Match[str]) -> str:
+            username = match.group("username")
+            if username.lower() in self._non_person_usernames:
+                return match.group(0)
+            self.counts["username"] += 1
+            return f"{match.group('prefix')}{self._map_username(username)}"
+
+        return self._encoded_home_path_pattern.sub(replace, text)
+
+    def _replace_known_unix_owner_group_usernames(self, text: str) -> str:
+        for username, replacement in list(self._username_map.items()):
+            if not re.fullmatch(r"[A-Za-z0-9._-]{3,}", username):
+                continue
+            if username in self._non_person_usernames:
+                continue
+            pattern = re.compile(
+                rf"(?<!\S){re.escape(username)}\s+{re.escape(username)}(?=\s+\d)",
+                re.IGNORECASE,
+            )
+            text, count = pattern.subn(f"{replacement} {replacement}", text)
+            if count:
+                self.counts["username"] += count * 2
+        return text
+
+    def _replace_api_keys(self, text: str) -> str:
+        for pattern in self._api_key_patterns:
+            text = pattern.sub(self._replace_prefixed_key, text)
+        text = self._jwt_pattern.sub(self._replace_jwt, text)
+        text = self._bearer_pattern.sub(self._replace_bearer, text)
+        text = self._generic_secret_pattern.sub(self._replace_generic_secret, text)
+        return text
+
+    def _map_username(self, username: str) -> str:
+        key = username.strip().lower()
+        if key not in self._username_map:
+            self._username_map[key] = f"user{len(self._username_map) + 1}"
+        return self._username_map[key]
+
+    def _replace_prefixed_key(self, match: re.Match[str]) -> str:
+        prefix = match.group("prefix")
+        token = match.group(0)
+        replacement = self._api_key_map.get(token)
+        if replacement is None:
+            replacement = prefix + self._dummy_sequence(token, 32)
+            self._api_key_map[token] = replacement
+            self._api_replacements.add(replacement)
+        self.counts["api_key"] += 1
+        return replacement
+
+    def _replace_jwt(self, match: re.Match[str]) -> str:
+        token = match.group(1)
+        replacement = self._api_key_map.get(token)
+        if replacement is None:
+            replacement = ".".join(
+                [
+                    "eyJ0eXAiOiJKV1Qi",
+                    self._dummy_sequence(token + ".payload", 24),
+                    self._dummy_sequence(token + ".signature", 32),
+                ]
+            )
+            self._api_key_map[token] = replacement
+            self._api_replacements.add(replacement)
+        self.counts["api_key"] += 1
+        return replacement
+
+    def _replace_bearer(self, match: re.Match[str]) -> str:
+        token = match.group(2)
+        if token in self._api_replacements:
+            return match.group(0)
+        replacement = self._api_key_map.get(token)
+        if replacement is None:
+            replacement = "redacted_" + self._dummy_sequence(token, 24)
+            self._api_key_map[token] = replacement
+            self._api_replacements.add(replacement)
+        self.counts["api_key"] += 1
+        return match.group(1) + replacement
+
+    def _replace_generic_secret(self, match: re.Match[str]) -> str:
+        token = match.group(2)
+        if token in self._api_replacements:
+            return match.group(0)
+        replacement = self._api_key_map.get(token)
+        if replacement is None:
+            replacement = "redacted_" + self._dummy_sequence(token, 24)
+            self._api_key_map[token] = replacement
+            self._api_replacements.add(replacement)
+        self.counts["api_key"] += 1
+        return match.group(1) + replacement
+
+    @staticmethod
+    def _dummy_sequence(seed: str, length: int) -> str:
+        alphabet = string.ascii_letters + string.digits
+        digest = hashlib.sha256(seed.encode("utf-8")).digest()
+        chars: list[str] = []
+        counter = 0
+        while len(chars) < length:
+            block = hashlib.sha256(digest + counter.to_bytes(4, "big")).digest()
+            chars.extend(alphabet[byte % len(alphabet)] for byte in block)
+            counter += 1
+        return "".join(chars[:length])

--- a/src/teich/cli.py
+++ b/src/teich/cli.py
@@ -15,7 +15,9 @@ from rich.live import Live
 from rich.panel import Panel
 from rich.table import Table
 
+from .anonymize import anonymize_path
 from .config import Config
+from .extract import ExtractProvider, extract_local_sessions
 from .runner import (
     ChatRunner,
     ClaudeCodeRunner,
@@ -37,6 +39,10 @@ app = typer.Typer(
     help="Generate agent training data using Codex, Pi, Claude Code, Hermes, or chat",
     no_args_is_help=True,
 )
+extract_app = typer.Typer(help="Extract local agent sessions into Teich output folders.")
+pool_app = typer.Typer(help="Upload anonymized traces to the Teich community pool.")
+app.add_typer(extract_app, name="extract")
+app.add_typer(pool_app, name="pool")
 NON_DATA_TRACE_DIR_NAMES = {"partials", "failures"}
 UPLOAD_IGNORE_PATTERNS = ["partials/**", "failures/**"]
 
@@ -101,15 +107,19 @@ def _try_write_completed_output_metadata(cfg: Config) -> Path | None:
         return None
 
 
-def _publish_dataset_to_hub(cfg: Config) -> str:
-    repo_id = cfg.get_publish_repo_id()
-    if not repo_id:
-        raise ValueError("No publish.repo_id configured")
-    api = HfApi(token=cfg.get_hf_token())
+def _upload_dataset_folder(
+    *,
+    folder_path: Path,
+    repo_id: str,
+    hf_token: str | None,
+    private: bool,
+    ignore_patterns: list[str],
+) -> str:
+    api = HfApi(token=hf_token)
     repo_url = api.create_repo(
         repo_id=repo_id,
         repo_type="dataset",
-        private=cfg.publish.private,
+        private=private,
         exist_ok=True,
     )
     delete_file = getattr(api, "delete_file", None)
@@ -127,20 +137,33 @@ def _publish_dataset_to_hub(cfg: Config) -> str:
     if callable(upload_large_folder):
         upload_large_folder(
             repo_id=repo_id,
-            folder_path=str(cfg.output.traces_dir),
+            folder_path=str(folder_path),
             repo_type="dataset",
-            private=cfg.publish.private,
-            ignore_patterns=_upload_ignore_patterns(cfg),
+            private=private,
+            ignore_patterns=ignore_patterns,
         )
     else:
         api.upload_folder(
-            folder_path=str(cfg.output.traces_dir),
+            folder_path=str(folder_path),
             repo_id=repo_id,
             repo_type="dataset",
             commit_message="Upload teich dataset output",
-            ignore_patterns=_upload_ignore_patterns(cfg),
+            ignore_patterns=ignore_patterns,
         )
     return str(repo_url)
+
+
+def _publish_dataset_to_hub(cfg: Config) -> str:
+    repo_id = cfg.get_publish_repo_id()
+    if not repo_id:
+        raise ValueError("No publish.repo_id configured")
+    return _upload_dataset_folder(
+        folder_path=cfg.output.traces_dir,
+        repo_id=repo_id,
+        hf_token=cfg.get_hf_token(),
+        private=cfg.publish.private,
+        ignore_patterns=_upload_ignore_patterns(cfg),
+    )
 
 
 def _prompt_publish_completed_outputs(cfg: Config) -> str | None:
@@ -169,6 +192,250 @@ def _print_interrupted_upload_hint(cfg: Config) -> None:
     console.print("[yellow]Skipping Hugging Face upload for interrupted run.[/yellow]")
     console.print("[cyan]To upload the completed outputs later, run this from the output folder:[/cyan]")
     console.print(f"  {upload_command}", soft_wrap=True)
+
+
+def _extract_dataset_config(
+    provider: ExtractProvider,
+    output: Path,
+    *,
+    model_filter: str | None = None,
+    repo_id: str | None = None,
+    hf_token: str | None = None,
+    private: bool = False,
+) -> Config:
+    model_id = model_filter or f"{provider}-local-sessions"
+    pretty_model = model_filter or provider
+    return Config.model_validate(
+        {
+            "agent": {"provider": provider},
+            "model": {"model": model_id},
+            "output": {
+                "traces_dir": output,
+                "pretty_name": f"{pretty_model} Agent Traces",
+            },
+            "publish": {
+                "repo_id": repo_id,
+                "hf_token": hf_token,
+                "private": private,
+            },
+        }
+    )
+
+
+def _write_extract_readme(
+    provider: ExtractProvider,
+    output: Path,
+    *,
+    model_filter: str | None = None,
+    repo_id: str | None = None,
+) -> Path:
+    cfg = _extract_dataset_config(provider, output, model_filter=model_filter, repo_id=repo_id)
+    return write_traces_readme(
+        cfg.output.traces_dir,
+        pretty_name=cfg.output.pretty_name,
+        tags=cfg.get_dataset_tags(),
+        model_id=cfg.model.model,
+        repo_id=cfg.get_publish_repo_id(),
+    )
+
+
+def _prompt_huggingface_upload(
+    provider: ExtractProvider,
+    output: Path,
+    *,
+    model_filter: str | None = None,
+    private: bool = False,
+) -> str | None:
+    should_upload = typer.confirm("Would you like to upload to Hugging Face?", default=False)
+    if not should_upload:
+        console.print("[yellow]Skipping Hugging Face upload.[/yellow]")
+        return None
+    repo_id = typer.prompt("Hugging Face dataset repo id (owner/name)").strip()
+    try:
+        cfg = _extract_dataset_config(provider, output, model_filter=model_filter, repo_id=repo_id, private=private)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    if not cfg.get_publish_repo_id():
+        console.print("[red]Hugging Face dataset repo id is required.[/red]")
+        raise typer.Exit(1)
+    hf_token = cfg.get_hf_token()
+    if not hf_token:
+        hf_token = typer.prompt("HF_TOKEN", hide_input=True).strip()
+        cfg = _extract_dataset_config(
+            provider,
+            output,
+            model_filter=model_filter,
+            repo_id=repo_id,
+            hf_token=hf_token,
+            private=private,
+        )
+        if not cfg.get_hf_token():
+            console.print("[red]HF_TOKEN is required to upload to Hugging Face.[/red]")
+            raise typer.Exit(1)
+    readme_path = _write_extract_readme(provider, output, model_filter=model_filter, repo_id=repo_id)
+    console.print(f"[green]Updated README:[/green] {readme_path}")
+    repo_url = _upload_dataset_folder(
+        folder_path=cfg.output.traces_dir,
+        repo_id=repo_id,
+        hf_token=cfg.get_hf_token(),
+        private=cfg.publish.private,
+        ignore_patterns=UPLOAD_IGNORE_PATTERNS,
+    )
+    console.print(f"[green]Published dataset:[/green] {repo_url}")
+    return repo_url
+
+
+def _run_extract_command(
+    provider: ExtractProvider,
+    output: Path,
+    sessions_dir: list[Path] | None,
+    *,
+    model_filter: str | None = None,
+    private: bool = False,
+) -> None:
+    console.print(Panel.fit("Teich Extract", style="bold blue"))
+    result = extract_local_sessions(
+        provider,
+        output_dir=output,
+        sources=sessions_dir,
+        model_filter=model_filter,
+        clear_destination=True,
+    )
+    if not result.source_paths:
+        console.print(f"[red]No local {provider} session folders found.[/red]")
+        console.print("[yellow]Pass one or more explicit folders with --sessions-dir.[/yellow]")
+        raise typer.Exit(1)
+    if not result.copied_files:
+        model_clause = f" matching model '{model_filter}'" if model_filter else ""
+        console.print(f"[yellow]Found {len(result.source_paths)} source path(s), but no {provider} sessions{model_clause} were extracted.[/yellow]")
+        for source in result.source_paths:
+            console.print(f"  - {source}")
+        raise typer.Exit(1)
+    stale_readme_path = output / "README.md"
+    if stale_readme_path.exists() and stale_readme_path.is_file():
+        stale_readme_path.unlink()
+    anonymize_report = anonymize_path(output, output, in_place=True)
+    readme_path = _write_extract_readme(provider, output, model_filter=model_filter)
+    totals = anonymize_report.totals
+    extracted_message = f"Extracted {result.count} {provider} trace{'s' if result.count != 1 else ''}"
+    if model_filter:
+        extracted_message += f" with {model_filter}"
+    console.print(f"[green]{extracted_message}[/green]", soft_wrap=True)
+    console.print(
+        "[cyan]Automatically scrambled[/cyan] "
+        f"{totals.get('api_key', 0)} API keys, "
+        f"{totals.get('email', 0)} email addresses, and "
+        f"{totals.get('username', 0)} username references",
+        soft_wrap=True,
+    )
+    console.print(f"[green]Wrote README:[/green] {readme_path}", soft_wrap=True)
+    console.print(f"[cyan]Data was written to[/cyan] {output}", soft_wrap=True)
+    for source in result.source_paths:
+        console.print(f"[dim]source: {source}[/dim]")
+    _prompt_huggingface_upload(provider, output, model_filter=model_filter, private=private)
+
+
+def _extract_sources_option() -> list[Path] | None:
+    return typer.Option(
+        None,
+        "--sessions-dir",
+        "-s",
+        help="Explicit session folder or file. Can be passed more than once.",
+    )
+
+
+def _extract_output_option() -> Path:
+    return typer.Option(Path("data"), "--output", "--out", "-o", help="Output directory root")
+
+
+def _extract_model_option() -> str | None:
+    return typer.Option(None, "--model", "-m", help="Only extract traces whose model metadata contains this value.")
+
+
+@extract_app.command()
+def codex(
+    output: Path = _extract_output_option(),
+    sessions_dir: list[Path] | None = _extract_sources_option(),
+    model: str | None = _extract_model_option(),
+    private: bool = typer.Option(False, "--private", help="Create the Hugging Face dataset as private if upload is confirmed."),
+) -> None:
+    """Extract local Codex sessions."""
+    _run_extract_command("codex", output, sessions_dir, model_filter=model, private=private)
+
+
+@extract_app.command()
+def claude(
+    output: Path = _extract_output_option(),
+    sessions_dir: list[Path] | None = _extract_sources_option(),
+    model: str | None = _extract_model_option(),
+    private: bool = typer.Option(False, "--private", help="Create the Hugging Face dataset as private if upload is confirmed."),
+) -> None:
+    """Extract local Claude Code sessions."""
+    _run_extract_command("claude", output, sessions_dir, model_filter=model, private=private)
+
+
+@extract_app.command()
+def pi(
+    output: Path = _extract_output_option(),
+    sessions_dir: list[Path] | None = _extract_sources_option(),
+    model: str | None = _extract_model_option(),
+    private: bool = typer.Option(False, "--private", help="Create the Hugging Face dataset as private if upload is confirmed."),
+) -> None:
+    """Extract local Pi sessions."""
+    _run_extract_command("pi", output, sessions_dir, model_filter=model, private=private)
+
+
+@extract_app.command()
+def hermes(
+    output: Path = _extract_output_option(),
+    sessions_dir: list[Path] | None = _extract_sources_option(),
+    model: str | None = _extract_model_option(),
+    private: bool = typer.Option(False, "--private", help="Create the Hugging Face dataset as private if upload is confirmed."),
+) -> None:
+    """Extract local Hermes Agent state sessions."""
+    _run_extract_command("hermes", output, sessions_dir, model_filter=model, private=private)
+
+
+@app.command()
+def anonymize(
+    input_path: Path = typer.Argument(Path("output"), help="Trace file or directory to anonymize"),
+    output: Path = typer.Option(
+        Path("output_anonymized"),
+        "--output",
+        "-o",
+        help="Anonymized output path. Ignored when --in-place is set.",
+    ),
+    in_place: bool = typer.Option(False, "--in-place", help="Overwrite files in the input path"),
+) -> None:
+    """Replace emails, home-directory usernames, and API keys with deterministic dummy values."""
+    try:
+        report = anonymize_path(input_path, output, in_place=in_place)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+    totals = report.totals
+    destination = report.input_path if in_place else report.output_path
+    console.print(f"[green]Anonymized {report.files_changed}/{len(report.files)} file(s) into {destination}[/green]")
+    if totals:
+        console.print(
+            "[cyan]Replacements:[/cyan] "
+            + " ".join(f"{key}={value}" for key, value in sorted(totals.items()))
+        )
+    else:
+        console.print("[yellow]No emails, usernames, or API keys were detected.[/yellow]")
+
+
+@pool_app.command("upload")
+def pool_upload(
+    path: Path = typer.Argument(Path("output_anonymized"), help="Anonymized trace directory to upload later"),
+) -> None:
+    """Placeholder for future Teich pool upload support."""
+    console.print("[yellow]teich pool upload is not wired to a deployed pool backend yet.[/yellow]")
+    console.print(f"[cyan]Ready path:[/cyan] {path}")
+    console.print("[dim]The command is reserved until the site has its database and upload API deployed.[/dim]")
+    raise typer.Exit(1)
 
 
 @app.command()

--- a/src/teich/extract.py
+++ b/src/teich/extract.py
@@ -1,0 +1,425 @@
+"""Local agent session discovery and extraction helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import os
+import re
+import shutil
+import sqlite3
+from typing import Any, Literal
+
+from .converter import normalize_claude_code_trace_events, normalize_codex_trace_events
+
+ExtractProvider = Literal["claude", "codex", "hermes", "pi"]
+
+
+@dataclass(frozen=True)
+class ExtractResult:
+    provider: ExtractProvider
+    destination_dir: Path
+    copied_files: list[Path] = field(default_factory=list)
+    source_paths: list[Path] = field(default_factory=list)
+
+    @property
+    def count(self) -> int:
+        return len(self.copied_files)
+
+
+def default_session_sources(provider: ExtractProvider, home: Path | None = None) -> list[Path]:
+    """Return likely local session stores for a supported provider."""
+    home = home or Path.home()
+    if provider == "codex":
+        return _existing_unique_paths(
+            [
+                _env_path("CODEX_HOME", "sessions"),
+                home / ".codex" / "sessions",
+            ]
+        )
+    if provider == "claude":
+        return _existing_unique_paths(
+            [
+                _env_path("CLAUDE_CONFIG_DIR", "projects"),
+                _env_path("CLAUDE_HOME", "projects"),
+                home / ".claude" / "projects",
+            ]
+        )
+    if provider == "pi":
+        return _existing_unique_paths(
+            [
+                _env_path("PI_SESSION_DIR"),
+                _env_path("PI_CODING_AGENT_DIR", "sessions"),
+                home / ".pi" / "agent" / "sessions",
+                home / ".pi" / "sessions",
+            ]
+        )
+    if provider == "hermes":
+        return _existing_unique_paths(
+            [
+                _env_path("HERMES_STATE_DB"),
+                _env_path("HERMES_HOME", "state.db"),
+                home / ".hermes" / "state.db",
+            ]
+        )
+    raise ValueError(f"Unsupported extract provider: {provider}")
+
+
+def extract_local_sessions(
+    provider: ExtractProvider,
+    *,
+    output_dir: Path = Path("data"),
+    sources: Iterable[Path] | None = None,
+    home: Path | None = None,
+    model_filter: str | None = None,
+    clear_destination: bool = False,
+) -> ExtractResult:
+    """Extract local sessions for provider into output_dir/provider."""
+    resolved_sources = _existing_unique_paths(list(sources) if sources is not None else default_session_sources(provider, home))
+    destination_dir = output_dir / _provider_output_name(provider)
+    if clear_destination and destination_dir.exists():
+        if destination_dir.is_dir():
+            shutil.rmtree(destination_dir)
+        else:
+            destination_dir.unlink()
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    if provider == "hermes":
+        copied_files = _extract_hermes_state_dbs(resolved_sources, destination_dir, model_filter=model_filter)
+    else:
+        copied_files = _extract_jsonl_session_files(
+            provider,
+            resolved_sources,
+            destination_dir,
+            model_filter=model_filter,
+        )
+    return ExtractResult(
+        provider=provider,
+        destination_dir=destination_dir,
+        copied_files=copied_files,
+        source_paths=resolved_sources,
+    )
+
+
+def _env_path(name: str, *parts: str) -> Path | None:
+    value = os.environ.get(name)
+    if not value:
+        return None
+    path = Path(value).expanduser()
+    for part in parts:
+        path /= part
+    return path
+
+
+def _existing_unique_paths(paths: Iterable[Path | None]) -> list[Path]:
+    seen: set[Path] = set()
+    result: list[Path] = []
+    for path in paths:
+        if path is None:
+            continue
+        expanded = path.expanduser()
+        if not expanded.exists():
+            continue
+        try:
+            key = expanded.resolve()
+        except OSError:
+            key = expanded
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(expanded)
+    return result
+
+
+def _provider_output_name(provider: ExtractProvider) -> str:
+    if provider == "claude":
+        return "claude-code"
+    return provider
+
+
+def _jsonl_files(source: Path) -> list[Path]:
+    if source.is_file() and source.suffix == ".jsonl":
+        return [source]
+    if not source.is_dir():
+        return []
+    return sorted(path for path in source.rglob("*.jsonl") if path.is_file())
+
+
+def _extract_jsonl_session_files(
+    provider: ExtractProvider,
+    sources: list[Path],
+    destination_dir: Path,
+    *,
+    model_filter: str | None = None,
+) -> list[Path]:
+    copied: list[Path] = []
+    for source in sources:
+        for path in _jsonl_files(source):
+            destination = _unique_destination(destination_dir, path.name)
+            if _copy_provider_jsonl(provider, path, destination, model_filter=model_filter):
+                copied.append(destination)
+    return copied
+
+
+def _copy_provider_jsonl(
+    provider: ExtractProvider,
+    source: Path,
+    destination: Path,
+    *,
+    model_filter: str | None = None,
+) -> bool:
+    events = _read_jsonl_dict_events(source)
+    if events is None:
+        if model_filter:
+            return False
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        return True
+    raw_model_matches = trace_matches_model(events, model_filter) if model_filter else True
+    if provider == "codex":
+        normalized_events = normalize_codex_trace_events(events, normalize_custom_tools=False)
+    elif provider == "claude":
+        normalized_events = normalize_claude_code_trace_events(events)
+    else:
+        normalized_events = events
+    if model_filter and not raw_model_matches and not trace_matches_model(normalized_events, model_filter):
+        return False
+    _write_jsonl_dict_events(destination, normalized_events)
+    try:
+        shutil.copystat(source, destination)
+    except OSError:
+        pass
+    return True
+
+
+def _read_jsonl_dict_events(path: Path) -> list[dict[str, Any]] | None:
+    events: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                event = json.loads(line)
+                if not isinstance(event, dict):
+                    return None
+                events.append(event)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return events
+
+
+def _write_jsonl_dict_events(path: Path, events: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+
+def _unique_destination(destination_dir: Path, file_name: str) -> Path:
+    destination = destination_dir / file_name
+    if not destination.exists():
+        return destination
+    stem = destination.stem
+    suffix = destination.suffix
+    counter = 1
+    while True:
+        candidate = destination.with_name(f"{stem}_{counter}{suffix}")
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def _extract_hermes_state_dbs(
+    sources: list[Path],
+    destination_dir: Path,
+    *,
+    model_filter: str | None = None,
+) -> list[Path]:
+    copied: list[Path] = []
+    for source in sources:
+        state_dbs = [source] if source.is_file() else sorted(source.rglob("state.db"))
+        for state_db in state_dbs:
+            copied.extend(_export_hermes_state_db(state_db, destination_dir, model_filter=model_filter))
+    return copied
+
+
+def _export_hermes_state_db(
+    state_db: Path,
+    destination_dir: Path,
+    *,
+    model_filter: str | None = None,
+) -> list[Path]:
+    if not state_db.exists():
+        return []
+    connection = sqlite3.connect(f"file:{state_db}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    try:
+        if not _has_table(connection, "sessions") or not _has_table(connection, "messages"):
+            return []
+        session_rows = connection.execute("SELECT * FROM sessions ORDER BY started_at ASC, id ASC").fetchall()
+        exported: list[Path] = []
+        for session_row in session_rows:
+            session_id = str(_sqlite_row_get(session_row, "id", "") or "")
+            if not session_id:
+                continue
+            message_rows = connection.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id ASC",
+                (session_id,),
+            ).fetchall()
+            events = _hermes_external_trace_events(session_row, message_rows)
+            if model_filter and not trace_matches_model(events, model_filter):
+                continue
+            destination = _unique_destination(destination_dir, f"hermes-agent-{_safe_file_id(session_id)}.jsonl")
+            _write_jsonl_dict_events(destination, events)
+            exported.append(destination)
+        return exported
+    finally:
+        connection.close()
+
+
+def _has_table(connection: sqlite3.Connection, table_name: str) -> bool:
+    row = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _sqlite_row_get(row: sqlite3.Row, key: str, default: Any = None) -> Any:
+    return row[key] if key in row.keys() else default
+
+
+def _safe_file_id(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.-]+", "-", value.strip()) or "session"
+
+
+def trace_matches_model(events: Iterable[dict[str, Any]], model_filter: str) -> bool:
+    """Return whether a trace has a model-identifying field matching model_filter."""
+    needle = _normalize_model_text(model_filter)
+    if not needle:
+        return True
+    return any(_value_has_matching_model(event, needle) for event in events)
+
+
+def _value_has_matching_model(value: Any, needle: str, *, key: str | None = None) -> bool:
+    if isinstance(value, dict):
+        return any(_value_has_matching_model(item, needle, key=str(item_key)) for item_key, item in value.items())
+    if isinstance(value, list):
+        return any(_value_has_matching_model(item, needle, key=key) for item in value)
+    if isinstance(value, str) and key and _is_model_key(key):
+        return needle in _normalize_model_text(value)
+    return False
+
+
+def _is_model_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "", key.lower())
+    if normalized in {
+        "model",
+        "modelid",
+        "modelname",
+        "modelslug",
+        "modelversion",
+        "selectedmodel",
+        "requestedmodel",
+        "defaultmodel",
+        "subagentmodel",
+    }:
+        return True
+    return normalized.endswith("model") and normalized not in {"modelconfig"}
+
+
+def _normalize_model_text(value: str) -> str:
+    return value.strip().casefold()
+
+
+def _timestamp(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        timestamp = value / 1000 if value > 10_000_000_000 else value
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _json_or_original(value: Any) -> Any:
+    if not isinstance(value, str) or not value.strip():
+        return value
+    if value.startswith("\x00json:"):
+        value = value[len("\x00json:"):]
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _hermes_external_trace_events(
+    session_row: sqlite3.Row,
+    message_rows: list[sqlite3.Row],
+) -> list[dict[str, Any]]:
+    session = dict(session_row)
+    input_tokens = _sqlite_row_get(session_row, "input_tokens")
+    output_tokens = _sqlite_row_get(session_row, "output_tokens")
+    total_tokens = _sqlite_row_get(session_row, "total_tokens")
+    if total_tokens is None and (input_tokens is not None or output_tokens is not None):
+        total_tokens = (input_tokens or 0) + (output_tokens or 0)
+    payload: dict[str, Any] = {
+        **session,
+        "source": "hermes-agent",
+        "hermes_source": _sqlite_row_get(session_row, "source"),
+        "timestamp": _timestamp(_sqlite_row_get(session_row, "started_at")),
+        "model": _sqlite_row_get(session_row, "model"),
+        "total_tokens": total_tokens,
+        "estimated_cost_usd": _sqlite_row_get(session_row, "estimated_cost_usd"),
+        "actual_cost_usd": _sqlite_row_get(session_row, "actual_cost_usd"),
+    }
+    model_config = _json_or_original(payload.get("model_config"))
+    if model_config is not None:
+        payload["model_config"] = model_config
+    events: list[dict[str, Any]] = [
+        {
+            "timestamp": payload["timestamp"],
+            "type": "external_session_meta",
+            "payload": payload,
+        }
+    ]
+    for message_row in message_rows:
+        event = _hermes_external_message_event(message_row)
+        if event is not None:
+            events.append(event)
+    return events
+
+
+def _hermes_external_message_event(row: sqlite3.Row) -> dict[str, Any] | None:
+    role = _sqlite_row_get(row, "role")
+    if not isinstance(role, str) or not role.strip():
+        return None
+    content = _json_or_original(_sqlite_row_get(row, "content")) or ""
+    if not isinstance(content, str):
+        content = json.dumps(content, ensure_ascii=False)
+    event: dict[str, Any] = {
+        "timestamp": _timestamp(_sqlite_row_get(row, "timestamp")),
+        "type": "external_message",
+        "role": role.strip(),
+        "content": content,
+    }
+    for key in (
+        "tool_call_id",
+        "tool_calls",
+        "token_count",
+        "finish_reason",
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+    ):
+        value = _json_or_original(_sqlite_row_get(row, key))
+        if value is not None and value != "":
+            event[key] = value
+    tool_name = _sqlite_row_get(row, "tool_name") or _sqlite_row_get(row, "name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        event["name"] = tool_name.strip()
+    return event

--- a/tests/test_extract_anonymize_cli.py
+++ b/tests/test_extract_anonymize_cli.py
@@ -1,0 +1,676 @@
+import json
+import sqlite3
+from pathlib import Path
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from teich.cli import app
+
+runner = CliRunner()
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain_cli_output(output: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", output)
+
+
+def test_extract_subcommands_exist():
+    for provider in ("claude", "codex", "hermes", "pi"):
+        result = runner.invoke(app, ["extract", provider, "--help"])
+
+        assert result.exit_code == 0
+        output = _plain_cli_output(result.output)
+        assert "--output" in output
+        assert "--out" in output
+        assert "--sessions-dir" in output
+        assert "--model" in output
+
+
+def test_extract_codex_from_explicit_sessions_dir(tmp_path: Path):
+    sessions_dir = tmp_path / "codex" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "session.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "session_meta", "payload": {"id": "session"}}),
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "hello"}],
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "output"
+    result = runner.invoke(
+        app,
+        ["extract", "codex", "--sessions-dir", str(sessions_dir), "--output", str(output_dir)],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0
+    extracted = output_dir / "codex" / "session.jsonl"
+    assert extracted.exists()
+    assert (output_dir / "README.md").exists()
+    assert "Extracted 1 codex trace" in result.output
+    assert "Automatically scrambled 0 API keys, 0 email addresses, and 0 username references" in result.output
+    assert "Data was written to" in result.output
+
+
+def test_extract_hermes_from_explicit_state_db(tmp_path: Path):
+    state_db = tmp_path / "state.db"
+    connection = sqlite3.connect(state_db)
+    try:
+        connection.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at TEXT, model TEXT)")
+        connection.execute(
+            "CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, timestamp TEXT)"
+        )
+        connection.execute(
+            "INSERT INTO sessions (id, source, started_at, model) VALUES (?, ?, ?, ?)",
+            ("session/1", "cli", "2026-06-13T00:00:00Z", "test-model"),
+        )
+        connection.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("session/1", "user", "hello", "2026-06-13T00:00:01Z"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    output_dir = tmp_path / "output"
+    result = runner.invoke(
+        app,
+        ["extract", "hermes", "--sessions-dir", str(state_db), "--output", str(output_dir)],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0
+    extracted = output_dir / "hermes" / "hermes-agent-session-1.jsonl"
+    assert extracted.exists()
+    rows = [json.loads(line) for line in extracted.read_text(encoding="utf-8").splitlines()]
+    assert rows[0]["type"] == "external_session_meta"
+    assert rows[0]["payload"]["source"] == "hermes-agent"
+    assert rows[1]["type"] == "external_message"
+    assert rows[1]["role"] == "user"
+    assert (output_dir / "README.md").exists()
+
+
+def test_extract_defaults_to_data_folder_and_anonymizes_before_prompt(tmp_path: Path):
+    sessions_dir = tmp_path / "codex" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    original_key = "sk-or-v1-abcdefghijklmnopqrstuvwxyz123456"
+    (sessions_dir / "session.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "session_meta", "payload": {"id": "session", "model": "test-model"}}),
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": f"hello from /home/alice/project alice@example.com {original_key}",
+                                }
+                            ],
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(app, ["extract", "codex", "--sessions-dir", str(sessions_dir)], input="n\n")
+        data_dir = Path("data")
+        text = (data_dir / "codex" / "session.jsonl").read_text(encoding="utf-8")
+
+    assert result.exit_code == 0
+    assert "Extracted 1 codex trace" in result.output
+    assert "Automatically scrambled 1 API keys, 1 email addresses, and 1 username references" in result.output
+    assert "Data was written to data" in result.output
+    assert "Would you like to upload to Hugging Face?" in result.output
+    assert "/home/user1/project" in text
+    assert "user1@example.com" in text
+    assert "sk-or-v1-" in text
+    assert original_key not in text
+    assert "alice@example.com" not in text
+
+
+def test_extract_model_filter_for_codex_claude_pi_and_hermes(tmp_path: Path):
+    codex_dir = tmp_path / "codex"
+    claude_dir = tmp_path / "claude"
+    pi_dir = tmp_path / "pi"
+    codex_dir.mkdir()
+    claude_dir.mkdir()
+    pi_dir.mkdir()
+    (codex_dir / "fable.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "codex-fable", "model": "codex-fable-5"}}) + "\n",
+        encoding="utf-8",
+    )
+    (codex_dir / "opus.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "codex-opus", "model": "codex-opus"}}) + "\n",
+        encoding="utf-8",
+    )
+    (claude_dir / "fable.jsonl").write_text(
+        json.dumps({"type": "assistant", "message": {"role": "assistant", "model": "claude-fable-5", "content": []}})
+        + "\n",
+        encoding="utf-8",
+    )
+    (claude_dir / "opus.jsonl").write_text(
+        json.dumps({"type": "assistant", "message": {"role": "assistant", "model": "claude-opus-4-8", "content": []}})
+        + "\n",
+        encoding="utf-8",
+    )
+    (pi_dir / "fable.jsonl").write_text(
+        json.dumps({"type": "session_info", "modelId": "pi-fable-5"}) + "\n",
+        encoding="utf-8",
+    )
+    (pi_dir / "opus.jsonl").write_text(
+        json.dumps({"type": "session_info", "modelId": "pi-opus"}) + "\n",
+        encoding="utf-8",
+    )
+    state_db = tmp_path / "state.db"
+    connection = sqlite3.connect(state_db)
+    try:
+        connection.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at TEXT, model TEXT)")
+        connection.execute(
+            "CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, timestamp TEXT)"
+        )
+        for session_id, model in (("hermes-fable", "hermes-fable-5"), ("hermes-opus", "hermes-opus")):
+            connection.execute(
+                "INSERT INTO sessions (id, source, started_at, model) VALUES (?, ?, ?, ?)",
+                (session_id, "cli", "2026-06-13T00:00:00Z", model),
+            )
+            connection.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+                (session_id, "user", "hello", "2026-06-13T00:00:01Z"),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+    cases = [
+        ("codex", codex_dir, "codex", "fable.jsonl"),
+        ("claude", claude_dir, "claude-code", "fable.jsonl"),
+        ("pi", pi_dir, "pi", "fable.jsonl"),
+        ("hermes", state_db, "hermes", "hermes-agent-hermes-fable.jsonl"),
+    ]
+    for provider, source, output_name, expected_file in cases:
+        output_dir = tmp_path / f"out-{provider}"
+        result = runner.invoke(
+            app,
+            [
+                "extract",
+                provider,
+                "--sessions-dir",
+                str(source),
+                "--output",
+                str(output_dir),
+                "--model",
+                "fable-5",
+            ],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert f"Extracted 1 {provider} trace with fable-5" in result.output
+        assert (output_dir / output_name / expected_file).exists()
+        assert len(list((output_dir / output_name).glob("*.jsonl"))) == 1
+
+
+def test_extract_refreshes_provider_output_before_writing(tmp_path: Path):
+    sessions_dir = tmp_path / "codex"
+    sessions_dir.mkdir()
+    (sessions_dir / "fable.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "codex-fable", "model": "codex-fable-5"}}) + "\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "data"
+    stale_file = output_dir / "codex" / "old-opus.jsonl"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "codex-opus", "model": "codex-opus"}}) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "README.md").write_text("old staged path: /home/stale/project\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "extract",
+            "codex",
+            "--sessions-dir",
+            str(sessions_dir),
+            "--output",
+            str(output_dir),
+            "--model",
+            "fable-5",
+        ],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Automatically scrambled 0 API keys, 0 email addresses, and 0 username references" in result.output
+    assert not stale_file.exists()
+    assert (output_dir / "codex" / "fable.jsonl").exists()
+    assert len(list((output_dir / "codex").glob("*.jsonl"))) == 1
+
+
+def test_extract_can_upload_staged_anonymized_output_to_huggingface(tmp_path: Path):
+    sessions_dir = tmp_path / "codex" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "session.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "session", "model": "codex-fable-5"}}) + "\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "data"
+
+    with patch("teich.cli.HfApi") as mock_api_cls:
+        mock_api = MagicMock()
+        mock_api.create_repo.return_value = "https://huggingface.co/datasets/armand0e/fable-traces"
+        mock_api_cls.return_value = mock_api
+
+        result = runner.invoke(
+            app,
+            [
+                "extract",
+                "codex",
+                "--sessions-dir",
+                str(sessions_dir),
+                "--output",
+                str(output_dir),
+                "--model",
+                "fable-5",
+            ],
+            input="y\narmand0e/fable-traces\n",
+            env={"HF_TOKEN": "hf-test-token"},
+        )
+
+    assert result.exit_code == 0
+    assert "Published dataset: https://huggingface.co/datasets/armand0e/fable-traces" in result.output
+    mock_api_cls.assert_called_once_with(token="hf-test-token")
+    mock_api.create_repo.assert_called_once_with(
+        repo_id="armand0e/fable-traces",
+        repo_type="dataset",
+        private=False,
+        exist_ok=True,
+    )
+    mock_api.upload_large_folder.assert_called_once_with(
+        repo_id="armand0e/fable-traces",
+        folder_path=str(output_dir),
+        repo_type="dataset",
+        private=False,
+        ignore_patterns=["partials/**", "failures/**"],
+    )
+    readme = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "armand0e/fable-traces" in readme
+
+
+def test_extract_prompts_for_hf_token_when_env_token_is_missing(tmp_path: Path):
+    sessions_dir = tmp_path / "codex" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "session.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "session", "model": "codex-fable-5"}}) + "\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "data"
+
+    with patch("teich.cli.HfApi") as mock_api_cls:
+        mock_api = MagicMock()
+        mock_api.create_repo.return_value = "https://huggingface.co/datasets/armand0e/fable-traces"
+        mock_api_cls.return_value = mock_api
+
+        result = runner.invoke(
+            app,
+            [
+                "extract",
+                "codex",
+                "--sessions-dir",
+                str(sessions_dir),
+                "--output",
+                str(output_dir),
+                "--model",
+                "fable-5",
+            ],
+            input="y\narmand0e/fable-traces\nhf-prompted-token\n",
+            env={"HF_TOKEN": "", "HUGGINGFACE_HUB_TOKEN": "", "TEICH_HF_TOKEN": ""},
+        )
+
+    assert result.exit_code == 0
+    assert "HF_TOKEN" in result.output
+    mock_api_cls.assert_called_once_with(token="hf-prompted-token")
+
+
+def test_extract_rejects_blank_huggingface_upload_inputs(tmp_path: Path):
+    sessions_dir = tmp_path / "codex" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "session.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "session", "model": "codex-fable-5"}}) + "\n",
+        encoding="utf-8",
+    )
+
+    with patch("teich.cli.HfApi") as mock_api_cls:
+        blank_repo = runner.invoke(
+            app,
+            ["extract", "codex", "--sessions-dir", str(sessions_dir), "--output", str(tmp_path / "blank-repo")],
+            input="y\n   \n",
+            env={"HF_TOKEN": "hf-test-token"},
+        )
+
+    assert blank_repo.exit_code == 1
+    assert "Hugging Face dataset repo id is required" in blank_repo.output
+    mock_api_cls.assert_not_called()
+
+    with patch("teich.cli.HfApi") as mock_api_cls:
+        blank_token = runner.invoke(
+            app,
+            ["extract", "codex", "--sessions-dir", str(sessions_dir), "--output", str(tmp_path / "blank-token")],
+            input="y\narmand0e/fable-traces\n   \n",
+            env={"HF_TOKEN": "", "HUGGINGFACE_HUB_TOKEN": "", "TEICH_HF_TOKEN": ""},
+        )
+
+    assert blank_token.exit_code == 1
+    assert "HF_TOKEN is required" in blank_token.output
+    mock_api_cls.assert_not_called()
+
+
+def test_anonymize_replaces_emails_keys_and_home_usernames_consistently(tmp_path: Path):
+    input_dir = tmp_path / "output"
+    input_dir.mkdir()
+    original_key = "sk-or-v1-abcdefghijklmnopqrstuvwxyz123456"
+    (input_dir / "trace.jsonl").write_text(
+        json.dumps(
+            {
+                "path": "/home/alice/project",
+                "windows_path": "C:\\Users\\alice\\Documents\\repo",
+                "encoded_project_path": "projects/-home-alice-Documents-repo/session.jsonl\n-home-alice",
+                "listing": "drwxrwxr-x 2 alice alice 4096 Jun 11 18:40 -home-alice",
+                "email": "alice@example.com",
+                "message": f"email alice@example.com key {original_key}",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "anonymized"
+    result = runner.invoke(app, ["anonymize", str(input_dir), "--output", str(output_dir)])
+
+    assert result.exit_code == 0
+    text = (output_dir / "trace.jsonl").read_text(encoding="utf-8")
+    assert "alice" not in text
+    assert "example.com" in text
+    assert "user1@example.com" in text
+    assert text.count("user1@example.com") == 2
+    assert "/home/user1/project" in text
+    assert "C:\\\\Users\\\\user1\\\\Documents" in text
+    assert "projects/-home-user1-Documents-repo/session.jsonl" in text
+    assert "-home-user1" in text
+    assert "user1 user1 4096" in text
+    assert "sk-or-v1-" in text
+    assert original_key not in text
+    assert "email=2" in result.output
+    assert "username=7" in result.output
+    assert "api_key=1" in result.output
+
+
+def test_anonymize_generalizes_to_synthetic_secret_and_reference_matrix(tmp_path: Path):
+    input_dir = tmp_path / "output"
+    input_dir.mkdir()
+    raw_values = {
+        "email": "dev.team+alerts@company.io",
+        "sk_ant": "sk-ant-api03-abcdefghijklmnopqrstuvwxyzABCDEFGHIJK",
+        "sk_proj": "sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJK",
+        "sk": "sk-abcdefghijklmnopqrstuvwxyzABCDEFGHIJK123456",
+        "hf": "hf_abcdefghijklmnopqrstuvwxyz123456",
+        "github_pat": "github_pat_abcdefghijklmnopqrstuvwxyz_1234567890",
+        "gho": "gho_abcdefghijklmnopqrstuvwxyz123456",
+        "glpat": "glpat-abcdefghijklmnopqrstuvwxyz123456",
+        "xoxb": "xoxb-abcdefghijklmnopqrstuvwxyz-123456",
+        "google": "AIzaabcdefghijklmnopqrstuvwxyz123456",
+        "jwt": (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbmUifQ."
+            "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        ),
+        "bearer": "Bearer abcdefghijklmnopqrstuvwxyz1234567890",
+        "env_secret": "PROJECT_SECRET=abcdefghijklmnopqrstuvwxyz1234567890",
+    }
+    image_data = "aGVsbG8=" * 40
+    (input_dir / "trace.jsonl").write_text(
+        json.dumps(
+            {
+                "content": "\n".join(
+                    [
+                        f"Contact {raw_values['email']} and then {raw_values['email']} again.",
+                        "/home/zoe/app /Users/zoe/app D:\\Users\\zoe\\Documents\\app",
+                        "projects/-Users-zoe-Documents-app/session.jsonl",
+                        "drwxr-xr-x 2 zoe zoe 4096 Jun 13 09:00 app",
+                        "Public path stays /Users/Public/Documents/shared",
+                        " ".join(raw_values[key] for key in raw_values if key != "email"),
+                        "Read @src/main.ts and @docs/*.md before editing.",
+                        "Install @scope/package and keep @media, @keyframes, @pytest.mark, @app.get.",
+                        "Remote git@gitlab.com:example/repo.git and https://medium.com/@someone/post stay.",
+                        "Keep code expression process.env.PROJECT_SECRET intact.",
+                    ]
+                ),
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/jpeg",
+                    "data": image_data,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "anonymized"
+    result = runner.invoke(app, ["anonymize", str(input_dir), "--output", str(output_dir)])
+
+    assert result.exit_code == 0
+    text = (output_dir / "trace.jsonl").read_text(encoding="utf-8")
+    for value in raw_values.values():
+        assert value not in text
+    assert "zoe" not in text
+    assert text.count("@example.com") == 2
+    assert "/home/user" in text
+    assert "/Users/user" in text
+    assert "D:\\\\Users\\\\user" in text
+    assert "-Users-user" in text
+    assert "/Users/Public/Documents/shared" in text
+    assert "sk-ant-api03-" in text
+    assert "sk-proj-" in text
+    assert "sk-" in text
+    assert "hf_" in text
+    assert "github_pat_" in text
+    assert "gho_" in text
+    assert "glpat-" in text
+    assert "xoxb-" in text
+    assert "AIza" in text
+    assert "eyJ0eXAiOiJKV1Qi." in text
+    assert "Bearer redacted_" in text
+    assert "PROJECT_SECRET=redacted_" in text
+    assert "process.env.PROJECT_SECRET" in text
+    assert image_data in text
+    assert "redacted_base64" not in text
+    assert "@src/main.ts" in text
+    assert "@docs/*.md" in text
+    assert "@scope/package" in text
+    assert "@media" in text
+    assert "@keyframes" in text
+    assert "@pytest.mark" in text
+    assert "@app.get" in text
+    assert "git@gitlab.com:example/repo.git" in text
+    assert "https://medium.com/@someone/post" in text
+
+
+def test_anonymize_keeps_secret_replacements_consistent_per_trace(tmp_path: Path):
+    input_dir = tmp_path / "output"
+    input_dir.mkdir()
+    key = "sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJK"
+    email = "operator@example.net"
+    (input_dir / "trace.jsonl").write_text(
+        json.dumps(
+            {
+                "first": f"{email} {key} /home/operator/app",
+                "second": f"{email} {key} /Users/operator/app",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "anonymized"
+    result = runner.invoke(app, ["anonymize", str(input_dir), "--output", str(output_dir)])
+
+    assert result.exit_code == 0
+    text = (output_dir / "trace.jsonl").read_text(encoding="utf-8")
+    emails = re.findall(r"user\d+@example\.com", text)
+    keys = re.findall(r"sk-proj-[A-Za-z0-9]{32}", text)
+    paths = re.findall(r"/(?:home|Users)/(user\d+)/app", text)
+    assert len(set(emails)) == 1
+    assert len(set(keys)) == 1
+    assert len(set(paths)) == 1
+    assert key not in text
+    assert email not in text
+    assert "operator" not in text
+
+
+def test_anonymize_scrubs_env_style_keys_without_scrubbing_tokenizer_terms(tmp_path: Path):
+    input_dir = tmp_path / "output"
+    input_dir.mkdir()
+    (input_dir / "trace.jsonl").write_text(
+        json.dumps(
+            {
+                "content": "\n".join(
+                    [
+                        'CONTEXT7_API_KEY: "ctx7sk-ba627c37-3cea-45c2-8808-720374cce2a3"',
+                        'HF_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"',
+                        "export const GROQ_API_KEY =",
+                        '  process.env.GROQ_API_KEY ?? "gsk_TESTabcdefghijklmnop";',
+                        'tokenizer = "AutoTokenizer.from_pretrained"',
+                        'PROCEDURAL_WARMUP_TOKENS = "abcdefghijklmnopqrstuvwxyz1234567890"',
+                        'adapter.supportsLocalAgentJwt = "abcdefghijklmnopqrstuvwxyz1234567890"',
+                    ]
+                )
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "anonymized"
+    result = runner.invoke(app, ["anonymize", str(input_dir), "--output", str(output_dir)])
+
+    assert result.exit_code == 0
+    text = (output_dir / "trace.jsonl").read_text(encoding="utf-8")
+    assert "ctx7sk-ba627c37-3cea-45c2-8808-720374cce2a3" not in text
+    assert "abcdefghijklmnopqrstuvwxyz1234567890" in text
+    assert "HF_TOKEN=\\\"redacted_" in text
+    assert "ctx7sk-" in text
+    assert "process.env.GROQ_API_KEY" in text
+    assert "gsk_TESTabcdefghijklmnop" not in text
+    assert "gsk_" in text
+    assert "AutoTokenizer.from_pretrained" in text
+    assert "PROCEDURAL_WARMUP_TOKENS" in text
+    assert "adapter.supportsLocalAgentJwt" in text
+    assert "api_key=3" in result.output
+
+
+def test_anonymize_preserves_base64_media_payloads_without_touching_metadata(tmp_path: Path):
+    input_dir = tmp_path / "output"
+    input_dir.mkdir()
+    image_data = "aGVsbG8=" * 40
+    (input_dir / "trace.jsonl").write_text(
+        json.dumps(
+            {
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": image_data,
+                        },
+                    }
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "anonymized"
+    result = runner.invoke(app, ["anonymize", str(input_dir), "--output", str(output_dir)])
+
+    assert result.exit_code == 0
+    row = json.loads((output_dir / "trace.jsonl").read_text(encoding="utf-8"))
+    source = row["content"][0]["source"]
+    assert source["type"] == "base64"
+    assert source["media_type"] == "image/png"
+    assert source["data"] == image_data
+    assert image_data in json.dumps(row)
+    assert "image_data" not in result.output
+
+
+def test_anonymize_does_not_treat_systemd_units_as_emails(tmp_path: Path):
+    input_dir = tmp_path / "output"
+    input_dir.mkdir()
+    (input_dir / "trace.jsonl").write_text(
+        json.dumps(
+            {
+                "content": "\n".join(
+                    [
+                        "Failed to start org.gnome.Shell@x11.service",
+                        "Read `@AGENT.md` before editing",
+                        "Also inspect @README.md and -@plan.md",
+                        "Read https://medium.com/@ahmed.soliman/why-anthropics",
+                        "origin git@github.com:CompactAIOfficial/MythosMini.git",
+                        "package source ssh://user3@example.com/user/repo",
+                        "contact 'lane@example.com' for help",
+                    ]
+                )
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "anonymized"
+    result = runner.invoke(app, ["anonymize", str(input_dir), "--output", str(output_dir)])
+
+    assert result.exit_code == 0
+    text = (output_dir / "trace.jsonl").read_text(encoding="utf-8")
+    assert "org.gnome.Shell@x11.service" in text
+    assert "`@AGENT.md`" in text
+    assert "@README.md" in text
+    assert "-@plan.md" in text
+    assert "https://medium.com/@ahmed.soliman/why-anthropics" in text
+    assert "git@github.com:CompactAIOfficial/MythosMini.git" in text
+    assert "ssh://user3@example.com/user/repo" in text
+    assert "lane@example.com" not in text
+    assert "user1@example.com" in text
+    assert "email=1" in result.output
+
+
+def test_pool_upload_is_reserved_until_backend_exists(tmp_path: Path):
+    result = runner.invoke(app, ["pool", "upload", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "not wired to a deployed pool backend yet" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1734,7 +1734,7 @@ wheels = [
 
 [[package]]
 name = "teich"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
## Summary
- add `teich extract claude|codex|pi|hermes` with default `data/` output, `--out`/`--output`, and metadata-based `--model` filtering
- stage extracted traces through automatic anonymization, generated dataset README creation, and an optional Hugging Face upload prompt
- add deterministic anonymization for API keys, emails, home-directory usernames, and encoded user path references while preserving embedded media payloads for conversation context
- avoid counting URI userinfo such as `ssh://user@example.com/repo` as an email address, while still scrubbing real `mailto:`/HTML contact email strings
- bump package version to `0.1.8` and document the extract/Hugging Face review flow

## Validation
- `uv run --python 3.12 --extra dev pytest -q -s` -> 406 passed, 21 skipped, 1 warning
- `uv run --python 3.12 --extra dev ruff check src/teich/anonymize.py tests/test_extract_anonymize_cli.py`
- `uv run --python 3.12 --extra dev python -m compileall -q src tests`
- `uv build`
- `uv pip check`
- real dry run: `uv run teich extract claude --sessions-dir output/pool_dry_run_raw/claude-code --model fable-5 --out /tmp/teich_extract_fable5_pr_check`
- decoded dry-run scan: 56 files / 14,912 rows, 0 invalid JSON, 0 files missing `fable-5`, 0 real email leaks, 0 home-user path leaks, 0 encoded-home path leaks, 49 prefixed API-key replacements with expected 32-character dummy bodies, 0 non-dummy API-key hits, 0 long secret assignments, 84 PNG and 2 JPEG media payloads preserved, 0 `redacted_base64` hits
- conversion check: extracted dry-run folder converted to 56 training rows
- Pi output classifier spot-check: skipped git remotes and `ssh://user@example.com/...` URI userinfo; remaining counted strings were generated/read HTML contact emails in `mailto:`/anchor content

Note: the dry-run scan found email-shaped non-email references, such as systemd unit names and git remotes, which are intentionally preserved.