### PR TITLE
Flatten extract output to root-level JSONL files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you already have local agent sessions, Teich can stage them as an anonymized 
 teich extract claude --model fable-5
 ```
 
-`extract` supports `claude`, `codex`, `pi`, and `hermes`. It writes anonymized traces to `data/` by default, generates a dataset `README.md`, and then asks whether to upload the folder to Hugging Face. Use `--out` / `--output` to choose another folder.
+`extract` supports `claude`, `codex`, `pi`, and `hermes`. It writes anonymized traces to `data/` by default, with JSONL files directly in that folder so the generated Hugging Face dataset metadata can match `*.jsonl`. It generates a dataset `README.md`, and then asks whether to upload the folder to Hugging Face. Use `--out` / `--output` to choose another folder.
 
 ## What Teich Supports
 

--- a/docs/generation.md
+++ b/docs/generation.md
@@ -48,7 +48,7 @@ teich extract pi
 teich extract hermes
 ```
 
-By default, extracted datasets are written to `data/` under the current directory. Use `--out` or `--output` to choose a different folder:
+By default, extracted datasets are written to `data/` under the current directory. JSONL traces are staged directly in that folder, matching the generated Hugging Face `*.jsonl` dataset metadata. Use `--out` or `--output` to choose a different folder:
 
 ```bash
 teich extract codex --model gpt-5-codex --out codex-data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "teich"
-version = "0.1.8"
+version = "0.2.0"
 description = "Turn coding agent traces into auditable supervised fine-tuning data"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/teich/__init__.py
+++ b/src/teich/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.1.8"
+__version__ = "0.2.0"
 
 from .audit import SFTAuditReport, audit_sft_dataset
 from .config import Config, load_config

--- a/src/teich/extract.py
+++ b/src/teich/extract.py
@@ -77,15 +77,12 @@ def extract_local_sessions(
     model_filter: str | None = None,
     clear_destination: bool = False,
 ) -> ExtractResult:
-    """Extract local sessions for provider into output_dir/provider."""
+    """Extract local sessions for provider into output_dir."""
     resolved_sources = _existing_unique_paths(list(sources) if sources is not None else default_session_sources(provider, home))
-    destination_dir = output_dir / _provider_output_name(provider)
-    if clear_destination and destination_dir.exists():
-        if destination_dir.is_dir():
-            shutil.rmtree(destination_dir)
-        else:
-            destination_dir.unlink()
+    destination_dir = output_dir
     destination_dir.mkdir(parents=True, exist_ok=True)
+    if clear_destination:
+        _clear_extract_destination(destination_dir)
     if provider == "hermes":
         copied_files = _extract_hermes_state_dbs(resolved_sources, destination_dir, model_filter=model_filter)
     else:
@@ -131,6 +128,23 @@ def _existing_unique_paths(paths: Iterable[Path | None]) -> list[Path]:
         seen.add(key)
         result.append(expanded)
     return result
+
+
+def _clear_extract_destination(destination_dir: Path) -> None:
+    """Remove stale extract artifacts while leaving unrelated files alone."""
+    for path in destination_dir.glob("*.jsonl"):
+        if path.is_file():
+            path.unlink()
+    for artifact_name in ("README.md", "tools.json"):
+        artifact_path = destination_dir / artifact_name
+        if artifact_path.is_file():
+            artifact_path.unlink()
+    for provider in ("claude", "codex", "hermes", "pi"):
+        legacy_dir = destination_dir / _provider_output_name(provider)
+        if legacy_dir.is_dir():
+            shutil.rmtree(legacy_dir)
+        elif legacy_dir.exists():
+            legacy_dir.unlink()
 
 
 def _provider_output_name(provider: ExtractProvider) -> str:

--- a/tests/test_extract_anonymize_cli.py
+++ b/tests/test_extract_anonymize_cli.py
@@ -59,7 +59,7 @@ def test_extract_codex_from_explicit_sessions_dir(tmp_path: Path):
     )
 
     assert result.exit_code == 0
-    extracted = output_dir / "codex" / "session.jsonl"
+    extracted = output_dir / "session.jsonl"
     assert extracted.exists()
     assert (output_dir / "README.md").exists()
     assert "Extracted 1 codex trace" in result.output
@@ -95,7 +95,7 @@ def test_extract_hermes_from_explicit_state_db(tmp_path: Path):
     )
 
     assert result.exit_code == 0
-    extracted = output_dir / "hermes" / "hermes-agent-session-1.jsonl"
+    extracted = output_dir / "hermes-agent-session-1.jsonl"
     assert extracted.exists()
     rows = [json.loads(line) for line in extracted.read_text(encoding="utf-8").splitlines()]
     assert rows[0]["type"] == "external_session_meta"
@@ -137,7 +137,7 @@ def test_extract_defaults_to_data_folder_and_anonymizes_before_prompt(tmp_path: 
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(app, ["extract", "codex", "--sessions-dir", str(sessions_dir)], input="n\n")
         data_dir = Path("data")
-        text = (data_dir / "codex" / "session.jsonl").read_text(encoding="utf-8")
+        text = (data_dir / "session.jsonl").read_text(encoding="utf-8")
 
     assert result.exit_code == 0
     assert "Extracted 1 codex trace" in result.output
@@ -205,12 +205,12 @@ def test_extract_model_filter_for_codex_claude_pi_and_hermes(tmp_path: Path):
         connection.close()
 
     cases = [
-        ("codex", codex_dir, "codex", "fable.jsonl"),
-        ("claude", claude_dir, "claude-code", "fable.jsonl"),
-        ("pi", pi_dir, "pi", "fable.jsonl"),
-        ("hermes", state_db, "hermes", "hermes-agent-hermes-fable.jsonl"),
+        ("codex", codex_dir, "fable.jsonl"),
+        ("claude", claude_dir, "fable.jsonl"),
+        ("pi", pi_dir, "fable.jsonl"),
+        ("hermes", state_db, "hermes-agent-hermes-fable.jsonl"),
     ]
-    for provider, source, output_name, expected_file in cases:
+    for provider, source, expected_file in cases:
         output_dir = tmp_path / f"out-{provider}"
         result = runner.invoke(
             app,
@@ -229,11 +229,11 @@ def test_extract_model_filter_for_codex_claude_pi_and_hermes(tmp_path: Path):
 
         assert result.exit_code == 0, result.output
         assert f"Extracted 1 {provider} trace with fable-5" in result.output
-        assert (output_dir / output_name / expected_file).exists()
-        assert len(list((output_dir / output_name).glob("*.jsonl"))) == 1
+        assert (output_dir / expected_file).exists()
+        assert len(list(output_dir.glob("*.jsonl"))) == 1
 
 
-def test_extract_refreshes_provider_output_before_writing(tmp_path: Path):
+def test_extract_refreshes_flat_output_before_writing(tmp_path: Path):
     sessions_dir = tmp_path / "codex"
     sessions_dir.mkdir()
     (sessions_dir / "fable.jsonl").write_text(
@@ -241,10 +241,16 @@ def test_extract_refreshes_provider_output_before_writing(tmp_path: Path):
         encoding="utf-8",
     )
     output_dir = tmp_path / "data"
-    stale_file = output_dir / "codex" / "old-opus.jsonl"
-    stale_file.parent.mkdir(parents=True)
+    output_dir.mkdir(parents=True)
+    stale_file = output_dir / "old-opus.jsonl"
     stale_file.write_text(
         json.dumps({"type": "session_meta", "payload": {"id": "codex-opus", "model": "codex-opus"}}) + "\n",
+        encoding="utf-8",
+    )
+    stale_legacy_file = output_dir / "codex" / "old-nested-opus.jsonl"
+    stale_legacy_file.parent.mkdir(parents=True)
+    stale_legacy_file.write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": "codex-nested-opus", "model": "codex-opus"}}) + "\n",
         encoding="utf-8",
     )
     (output_dir / "README.md").write_text("old staged path: /home/stale/project\n", encoding="utf-8")
@@ -267,8 +273,10 @@ def test_extract_refreshes_provider_output_before_writing(tmp_path: Path):
     assert result.exit_code == 0
     assert "Automatically scrambled 0 API keys, 0 email addresses, and 0 username references" in result.output
     assert not stale_file.exists()
-    assert (output_dir / "codex" / "fable.jsonl").exists()
-    assert len(list((output_dir / "codex").glob("*.jsonl"))) == 1
+    assert not stale_legacy_file.exists()
+    assert not stale_legacy_file.parent.exists()
+    assert (output_dir / "fable.jsonl").exists()
+    assert len(list(output_dir.glob("*.jsonl"))) == 1
 
 
 def test_extract_can_upload_staged_anonymized_output_to_huggingface(tmp_path: Path):
@@ -319,6 +327,7 @@ def test_extract_can_upload_staged_anonymized_output_to_huggingface(tmp_path: Pa
     )
     readme = (output_dir / "README.md").read_text(encoding="utf-8")
     assert "armand0e/fable-traces" in readme
+    assert 'path: "*.jsonl"' in readme
 
 
 def test_extract_prompts_for_hf_token_when_env_token_is_missing(tmp_path: Path):

--- a/uv.lock
+++ b/uv.lock
@@ -1734,7 +1734,7 @@ wheels = [
 
 [[package]]
 name = "teich"
-version = "0.1.8"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
## Summary
- write `teich extract` JSONL files directly into the selected output folder so generated Hugging Face dataset metadata `path: "*.jsonl"` resolves correctly
- refresh stale root JSONL files plus legacy provider subfolders before writing new extract output
- document the flat output contract and bump package metadata to `0.2.0`

## Root Cause
`teich extract` was staging traces under provider subfolders, but the generated dataset README advertises root-level `*.jsonl` files. Hugging Face dataset loading follows that metadata, so nested trace files could be missed.

## Validation
- `uv run --extra dev pytest -q tests/test_extract_anonymize_cli.py -s` -> 16 passed
- `uv run --extra dev ruff check src/teich/extract.py tests/test_extract_anonymize_cli.py`
- `uv run python -m compileall -q src tests`
- `uv run --python 3.12 --extra dev pytest -q -s` -> 406 passed, 21 skipped, 1 warning
- `uv build` -> built `teich-0.2.0` sdist and wheel
- `uv run python -c "import teich; print(teich.__version__)"` -> `0.2.0`
- `uv pip check` -> all installed packages compatible
- real dry run: `uv run teich extract claude --sessions-dir output/pool_dry_run_raw/claude-code --model fable-5 --out /tmp/teich_extract_flat_check`
- dry-run layout check: 56 root-level JSONL files, 0 nested JSONL files, README `data_files` path remains `*.jsonl`