### PR TITLE
Avoid double conversion of Path in convert_traces_to_training_data()

### DIFF
--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -3628,7 +3628,7 @@ def _convert_jsonl_file_to_training_rows(jsonl_file: Path) -> list[dict[str, Any
 
 
 def convert_traces_to_training_data(traces_dir: Path | str) -> list[dict[str, Any]]:
-    source = Path(traces_dir)
+    source = traces_dir if not isinstance(traces_dir, Path) else Path(traces_dir)
     trace_files = _jsonl_files(source)
     rows: list[dict[str, Any]] = []
     for path in trace_files:

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -3628,7 +3628,7 @@ def _convert_jsonl_file_to_training_rows(jsonl_file: Path) -> list[dict[str, Any
 
 
 def convert_traces_to_training_data(traces_dir: Path | str) -> list[dict[str, Any]]:
-    source = traces_dir if not isinstance(traces_dir, Path) else Path(traces_dir)
+    source = Path(traces_dir) if not isinstance(traces_dir, Path) else traces_dir
     trace_files = _jsonl_files(source)
     rows: list[dict[str, Any]] = []
     for path in trace_files:


### PR DESCRIPTION
This seems minor but at HF we actually use `xPath` which supports URIs like `hf://...`, so this change actually enables this:

```python
remote_path = xPath("hf://datasets/.../sessions.jsonl")
training_data = convert_traces_to_training_data(remote_path)
```