### PR TITLE
Codex runner: host auth, fast mode, config passthroughs, trace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ publish:
 
 `agent.provider: chat` writes structured chat rows directly and does not require Docker. Agent providers preserve raw or native traces as source-of-truth artifacts.
 
+To run Codex on your ChatGPT subscription instead of an API key, set `agent.codex.use_host_auth: true` (Teich shares your host `codex login` across containers), and enable Codex fast mode with `model.service_tier: fast`. See [Generation](docs/generation.md#using-your-chatgpt-subscription-host-auth).
+
 ## Python Entry Points
 
 ```python

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,20 @@ agent:
   # chat = direct text-only dataset generation via an OpenAI-compatible API
   provider: pi
 
+  # Codex-only: use your ChatGPT subscription instead of an API key. Teich seeds
+  # one auth.json snapshot from your host login ($CODEX_HOME/auth.json or
+  # ~/.codex/auth.json) into auth_dir, then runs a host-side broker that owns the
+  # rotating refresh token. Each container gets its own seeded auth.json (refresh
+  # token swapped for a per-run secret) and refreshes through the broker, which
+  # single-flights rotation, so any max_concurrency is safe.
+  # NOTE: the first rotation invalidates your host `codex` login; run `codex
+  # login` again afterward to restore it. auth_dir holds live credentials, so
+  # Teich keeps it out of output/sandbox/failures and gitignores it.
+  # codex:
+  #   use_host_auth: true
+  #   host_auth_file: null            # default: $CODEX_HOME/auth.json or ~/.codex/auth.json
+  #   auth_dir: ./.teich/codex-auth
+
 model:
   # Model id passed to the selected agent/provider.
   model: deepseek/deepseek-v4-flash
@@ -32,6 +46,12 @@ model:
   # Hermes also enables built-in toolsets:
   # safe,terminal,file,skills,memory,session_search,delegation
   reasoning_effort: medium
+
+  # Optional Codex service tier. Set to "fast" to enable Codex fast mode: it
+  # runs ~1.5x faster at a higher credit rate and requires ChatGPT subscription
+  # auth (agent.codex.use_host_auth) plus a supported model such as gpt-5.5 or
+  # gpt-5.4. Leave null for the standard tier.
+  service_tier: null
 
   # Optional context length override for providers that support it.
   # Useful for Hermes custom endpoints when /v1/models reports a served

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,12 @@ model:
   # safe,terminal,file,skills,memory,session_search,delegation
   reasoning_effort: medium
 
+  # Optional Codex reasoning-summary detail, forwarded as model_reasoning_summary.
+  # Values: auto | concise | detailed | none. Set to "detailed" to capture rich
+  # reasoning summaries in traces (Codex's default can emit empty summaries).
+  # Leave null to use Codex's default.
+  reasoning_summary: null
+
   # Optional Codex service tier. Set to "fast" to enable Codex fast mode: it
   # runs ~1.5x faster at a higher credit rate and requires ChatGPT subscription
   # auth (agent.codex.use_host_auth) plus a supported model such as gpt-5.5 or

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -151,5 +151,13 @@ timeout_seconds: 600
 # Prefer env vars or api.api_key above for new configs.
 openai_api_key: null
 
-# Optional developer instructions injected into the runtime.
+# Optional developer/system instructions injected into every agent run.
+# Applied across codex (developer_instructions), claude-code and pi
+# (--append-system-prompt), and hermes (AGENTS.md) — additive, so the agent's
+# built-in base prompt is preserved. Handy for nudging chain-of-thought into the
+# trace, e.g.:
+#   developer_instructions: |
+#     Think out loud so your problem-solving process is visible. Before each tool
+#     call or edit, briefly explain what you're doing and why; after a command or
+#     test runs, state what you concluded before the next step.
 developer_instructions: null

--- a/docs/generation.md
+++ b/docs/generation.md
@@ -239,6 +239,19 @@ model:
 
 Teich writes `service_tier = "fast"` into the container's `config.toml`. Fast mode requires ChatGPT subscription auth (set `agent.codex.use_host_auth: true` above) and a supported model; with an API key Codex falls back to standard pricing. `service_tier` is a free-form passthrough, so other tiers (e.g. `flex`) also work.
 
+#### Reasoning summaries
+
+Codex reasoning models only return their chain-of-thought as opaque encrypted content plus human-readable **summaries**; the summaries are what teich records in traces (as `reasoning_text`). Codex's default summary setting can yield empty summaries (`summary: []`). To capture richer reasoning in your traces, set the summary detail:
+
+```yaml
+model:
+  model: gpt-5.5
+  reasoning_effort: xhigh     # depth of reasoning
+  reasoning_summary: detailed # how much of it is summarized into the trace
+```
+
+Teich writes `model_reasoning_summary = "detailed"` into `config.toml`. Values are `auto | concise | detailed | none` (free-form passthrough); leave unset to use Codex's default. Note this controls the *summary* of the reasoning, not the raw chain-of-thought — Codex/OpenAI never return the full raw CoT in plaintext.
+
 ### `pi`
 
 Copies native Pi session JSONL from mounted `/home/codex/pi-sessions`, then normalizes and validates tool-call structure before writing output.

--- a/docs/generation.md
+++ b/docs/generation.md
@@ -201,6 +201,44 @@ Copies native Codex session JSONL from mounted `CODEX_HOME/sessions` and normali
 
 Teich appends configured `tool_schema` metadata so tools remain available for training even if the model did not call them.
 
+#### Using your ChatGPT subscription (host auth)
+
+By default Codex runs on an API key. To run it on your ChatGPT subscription instead, point Teich at your host Codex login:
+
+```yaml
+agent:
+  provider: codex
+  codex:
+    use_host_auth: true
+    # host_auth_file: null          # defaults to $CODEX_HOME/auth.json or ~/.codex/auth.json
+    # auth_dir: ./.teich/codex-auth # where the auth snapshot lives during a run
+```
+
+You must have logged in on the host first (`codex login`). When enabled, Teich:
+
+1. Copies your host `auth.json` **once** into `auth_dir` as a snapshot. It re-seeds from the host only when the host file is newer, so a token already rotated in place is never clobbered by a stale host copy.
+2. Starts a single host-side **token broker** that owns the rotating OAuth refresh token for the whole run. Each Codex container is seeded with its own `auth.json` whose `refresh_token` is a per-run secret, and is pointed at the broker via `CODEX_REFRESH_TOKEN_URL_OVERRIDE`. The broker is the sole caller of the real refresh endpoint, so the durable refresh token never enters a container.
+3. Passes **no** `*_API_KEY` env into the container, so Codex uses the subscription tokens even if an ambient `OPENAI_API_KEY` is set in your shell.
+
+Important caveats (Codex's OAuth refresh tokens are single-use/rotating):
+
+- **Your host login gets invalidated.** The first time the broker rotates the token, the server invalidates your interactive `codex` login on the host. Run `codex login` again on the host afterward to restore it. (Use a dedicated Codex login for batch runs if you don't want to disturb your daily one.)
+- **`auth_dir` holds credentials.** Teich refuses to place it under `traces_dir`/`sandbox_dir`/`failures_dir` (those are uploaded) and drops a `.gitignore` (`*`) into it so the snapshot isn't committed. Like the output dirs, `auth_dir` is resolved relative to the directory you run `teich` from (not the config file's location).
+- **Concurrency is safe.** The broker single-flights rotation and hands the same live access token to every container, so concurrent containers can't invalidate one another's tokens — any `max_concurrency` works.
+- To re-seed from a fresh host login, delete `auth_dir` (or just its `auth.json`).
+
+#### Fast mode
+
+Codex "fast mode" is a service tier (not a model or reasoning level) that runs a supported model faster at a higher credit rate. Enable it with:
+
+```yaml
+model:
+  model: gpt-5.5      # fast mode supports gpt-5.5 / gpt-5.4
+  service_tier: fast
+```
+
+Teich writes `service_tier = "fast"` into the container's `config.toml`. Fast mode requires ChatGPT subscription auth (set `agent.codex.use_host_auth: true` above) and a supported model; with an API key Codex falls back to standard pricing. `service_tier` is a free-form passthrough, so other tiers (e.g. `flex`) also work.
+
 ### `pi`
 
 Copies native Pi session JSONL from mounted `/home/codex/pi-sessions`, then normalizes and validates tool-call structure before writing output.

--- a/docs/generation.md
+++ b/docs/generation.md
@@ -252,6 +252,28 @@ model:
 
 Teich writes `model_reasoning_summary = "detailed"` into `config.toml`. Values are `auto | concise | detailed | none` (free-form passthrough); leave unset to use Codex's default. Note this controls the *summary* of the reasoning, not the raw chain-of-thought — Codex/OpenAI never return the full raw CoT in plaintext.
 
+### Developer instructions / CoT narration (all agents)
+
+The top-level `developer_instructions` config is injected into **every** agent run as additive system/developer guidance, via each agent's native mechanism:
+
+| Agent | Mechanism |
+|-------|-----------|
+| codex | `developer_instructions` in `config.toml` |
+| claude-code | `--append-system-prompt` |
+| pi | `--append-system-prompt` |
+| hermes | auto-loaded `AGENTS.md` in the workspace (appended, so a cloned repo's own `AGENTS.md` is preserved) |
+
+It augments each agent's built-in base prompt rather than replacing it. A useful pattern for training data is to nudge the agent to narrate its reasoning in its visible output, which lands in the trace (and SFT rows) alongside Codex's reasoning summaries:
+
+```yaml
+developer_instructions: |
+  Think out loud so your problem-solving process is visible. Before each tool
+  call or edit, briefly explain what you're doing and why; after a command or
+  test runs, state what you concluded before the next step.
+```
+
+This produces reasoning *narration* in the assistant messages — not the model's hidden raw chain-of-thought, which providers don't expose. (The `chat` provider is text-only distillation and uses per-prompt `system` instead.)
+
 ### `pi`
 
 Copies native Pi session JSONL from mounted `/home/codex/pi-sessions`, then normalizes and validates tool-call structure before writing output.

--- a/src/teich/cli.py
+++ b/src/teich/cli.py
@@ -1166,7 +1166,15 @@ timeout_seconds: 600
 # Prefer env vars or api.api_key above for new configs.
 openai_api_key: null
 
-# Optional developer instructions injected into the runtime.
+# Optional developer/system instructions injected into every agent run.
+# Applied across codex (developer_instructions), claude-code and pi
+# (--append-system-prompt), and hermes (AGENTS.md) — additive, so the agent's
+# built-in base prompt is preserved. Handy for nudging chain-of-thought into the
+# trace, e.g.:
+#   developer_instructions: |
+#     Think out loud so your problem-solving process is visible. Before each tool
+#     call or edit, briefly explain what you're doing and why; after a command or
+#     test runs, state what you concluded before the next step.
 developer_instructions: null
 '''
 

--- a/src/teich/cli.py
+++ b/src/teich/cli.py
@@ -716,6 +716,15 @@ def generate(
     try:
         if agent_provider == "codex":
             runner = CodexRunner(cfg)
+            if cfg.agent.codex.use_host_auth:
+                console.print(
+                    "[yellow]Codex host-auth enabled: using your ChatGPT subscription via "
+                    f"{cfg.get_codex_host_auth_source()}.[/yellow]"
+                )
+                console.print(
+                    "[yellow]Heads up: once the rotating token is refreshed, your host Codex login "
+                    "will be invalidated — run `codex login` on the host afterward to restore it.[/yellow]"
+                )
         elif agent_provider == "pi":
             runner = PiRunner(cfg)
         elif agent_provider in {"claude", "claude-code", "claude_code"}:
@@ -1021,6 +1030,20 @@ agent:
   # chat = direct text-only dataset generation via an OpenAI-compatible API
   provider: pi
 
+  # Codex-only: use your ChatGPT subscription instead of an API key. Teich seeds
+  # one auth.json snapshot from your host login ($CODEX_HOME/auth.json or
+  # ~/.codex/auth.json) into auth_dir, then runs a host-side broker that owns the
+  # rotating refresh token. Each container gets its own seeded auth.json (refresh
+  # token swapped for a per-run secret) and refreshes through the broker, which
+  # single-flights rotation, so any max_concurrency is safe.
+  # NOTE: the first rotation invalidates your host `codex` login; run `codex
+  # login` again afterward to restore it. auth_dir holds live credentials, so
+  # Teich keeps it out of output/sandbox/failures and gitignores it.
+  # codex:
+  #   use_host_auth: true
+  #   host_auth_file: null            # default: $CODEX_HOME/auth.json or ~/.codex/auth.json
+  #   auth_dir: ./.teich/codex-auth
+
 model:
   # Model id passed to the selected agent/provider.
   model: deepseek/deepseek-v4-flash
@@ -1038,6 +1061,12 @@ model:
   # Hermes also enables built-in toolsets:
   # safe,terminal,file,skills,memory,session_search,delegation
   reasoning_effort: medium
+
+  # Optional Codex service tier. Set to "fast" to enable Codex fast mode: it
+  # runs ~1.5x faster at a higher credit rate and requires ChatGPT subscription
+  # auth (agent.codex.use_host_auth) plus a supported model such as gpt-5.5 or
+  # gpt-5.4. Leave null for the standard tier.
+  service_tier: null
 
   # Optional context length override for providers that support it.
   # Useful for Hermes custom endpoints when /v1/models reports a served

--- a/src/teich/cli.py
+++ b/src/teich/cli.py
@@ -1062,6 +1062,12 @@ model:
   # safe,terminal,file,skills,memory,session_search,delegation
   reasoning_effort: medium
 
+  # Optional Codex reasoning-summary detail, forwarded as model_reasoning_summary.
+  # Values: auto | concise | detailed | none. Set to "detailed" to capture rich
+  # reasoning summaries in traces (Codex's default can emit empty summaries).
+  # Leave null to use Codex's default.
+  reasoning_summary: null
+
   # Optional Codex service tier. Set to "fast" to enable Codex fast mode: it
   # runs ~1.5x faster at a higher credit rate and requires ChatGPT subscription
   # auth (agent.codex.use_host_auth) plus a supported model such as gpt-5.5 or

--- a/src/teich/codex_auth_broker.py
+++ b/src/teich/codex_auth_broker.py
@@ -1,0 +1,348 @@
+"""In-process token broker for Codex ChatGPT-subscription host auth.
+
+When ``agent.codex.use_host_auth`` is enabled, teich runs a single host-side
+broker that owns the rotating ChatGPT OAuth refresh token for the whole run.
+Every Codex container is pointed at the broker via
+``CODEX_REFRESH_TOKEN_URL_OVERRIDE`` and seeded with its own ``auth.json`` whose
+``refresh_token`` is a per-run secret -- the real refresh token never enters a
+container. The broker hands the same live access token to every container and
+performs the single-use refresh-token rotation centrally, so concurrent
+containers can no longer invalidate one another (which is what happens when N
+containers each rotate a shared ``auth.json`` against ``auth.openai.com``).
+
+The broker stores and rotates only the copy in ``auth_dir`` (next to the teich
+config); it never touches the host ``~/.codex/auth.json``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import secrets
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+# Real OpenAI OAuth refresh endpoint + the Codex CLI client id. Both are
+# injectable so tests can point at a local fake without network access.
+REAL_REFRESH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+REAL_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+# Codex proactively refreshes when the access token is within 5 minutes of
+# expiry. Rotate a little earlier so a token we hand back is never already
+# inside Codex's window -- otherwise Codex would refresh again on the very next
+# request and loop.
+ROTATE_WINDOW_SECONDS = 6 * 60
+
+REFRESH_PATH = "/oauth/token"
+
+# A refresh request body is tiny; cap reads so a bogus Content-Length can't
+# exhaust memory (the broker listens on 0.0.0.0).
+MAX_REQUEST_BYTES = 64 * 1024
+
+
+def _decode_jwt_exp(token: str) -> int | None:
+    """Return the ``exp`` claim (unix seconds) from a JWT without verifying it."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        # binascii.Error (malformed base64) is a subclass of ValueError.
+        decoded = base64.urlsafe_b64decode(payload + padding)
+        claims = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    exp = claims.get("exp") if isinstance(claims, dict) else None
+    if isinstance(exp, bool) or not isinstance(exp, (int, float)):
+        return None
+    try:
+        return int(exp)  # int(float("inf")) / NaN raise OverflowError/ValueError
+    except (OverflowError, ValueError):
+        return None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class _UpstreamRefreshError(Exception):
+    """Carries an upstream OAuth failure so the broker can relay it to Codex.
+
+    Codex classifies the response body's ``error.code`` (e.g.
+    ``refresh_token_reused``) to decide whether the failure is permanent, so we
+    pass the upstream status + body straight through.
+    """
+
+    def __init__(self, status: int, payload: dict[str, Any]):
+        super().__init__(f"upstream refresh failed: {status}")
+        self.status = status
+        self.payload = payload
+
+
+class CodexTokenBroker:
+    """Single owner of the rotating ChatGPT refresh token for a teich run."""
+
+    def __init__(
+        self,
+        auth_json_path: Path | str,
+        *,
+        refresh_url: str = REAL_REFRESH_TOKEN_URL,
+        client_id: str = REAL_OAUTH_CLIENT_ID,
+        host: str = "0.0.0.0",
+        port: int = 0,
+        rotate_window_seconds: int = ROTATE_WINDOW_SECONDS,
+        upstream_timeout: float = 30.0,
+    ) -> None:
+        self._auth_json_path = Path(auth_json_path)
+        self._refresh_url = refresh_url
+        self._client_id = client_id
+        self._host = host
+        self._requested_port = port
+        self._rotate_window_seconds = rotate_window_seconds
+        self._upstream_timeout = upstream_timeout
+        self._lock = threading.Lock()
+        # Per-run shared secret. Containers receive this as their auth.json
+        # refresh_token; the broker only serves callers that present it.
+        self.secret = secrets.token_urlsafe(32)
+        self._auth = self._load_auth()
+        self._validate_chatgpt_auth(self._auth)
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self.port: int | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+    def start(self) -> None:
+        if self._server is not None:
+            return
+        server = _BrokerServer((self._host, self._requested_port), _BrokerHandler, self)
+        self.port = server.server_address[1]
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name="teich-codex-token-broker",
+            daemon=True,
+        )
+        thread.start()
+        self._server = server
+        self._thread = thread
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+        self.port = None
+
+    @property
+    def override_url(self) -> str:
+        """The ``CODEX_REFRESH_TOKEN_URL_OVERRIDE`` value for containers."""
+        if self.port is None:
+            raise RuntimeError("CodexTokenBroker.start() has not been called")
+        return f"http://host.docker.internal:{self.port}{REFRESH_PATH}"
+
+    # -- container seed ----------------------------------------------------
+    def seed_auth_json(self) -> dict[str, Any]:
+        """A container-safe ``auth.json``: real tokens but the refresh token
+        replaced by the per-run secret, so the durable refresh token stays on
+        the host."""
+        with self._lock:
+            auth = json.loads(json.dumps(self._auth))  # deep copy
+        tokens = auth.setdefault("tokens", {})
+        tokens["refresh_token"] = self.secret
+        return auth
+
+    # -- refresh handling --------------------------------------------------
+    def handle_refresh(self, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        """Core of the broker: validate the caller, return the current access
+        token, rotating once upstream only when it is near expiry."""
+        incoming = body.get("refresh_token")
+        if not isinstance(incoming, str) or not secrets.compare_digest(incoming, self.secret):
+            return 401, {
+                "error": {
+                    "code": "invalid_grant",
+                    "message": "unrecognized refresh token",
+                }
+            }
+        with self._lock:
+            tokens = self._auth.get("tokens", {})
+            if self._needs_rotation(tokens.get("access_token", "")):
+                try:
+                    self._rotate()
+                except _UpstreamRefreshError as exc:
+                    return exc.status, exc.payload
+            return 200, self._refresh_response()
+
+    def _needs_rotation(self, access_token: str) -> bool:
+        exp = _decode_jwt_exp(access_token)
+        if exp is not None:
+            return exp <= time.time() + self._rotate_window_seconds
+        # No parseable exp -> rotate once to obtain a fresh JWT.
+        return True
+
+    def _refresh_response(self) -> dict[str, Any]:
+        tokens = self._auth.get("tokens", {})
+        return {
+            "id_token": tokens.get("id_token"),
+            "access_token": tokens.get("access_token"),
+            # Hand back the secret, never the real refresh token.
+            "refresh_token": self.secret,
+        }
+
+    def _rotate(self) -> None:
+        tokens = self._auth.setdefault("tokens", {})
+        request_body = json.dumps(
+            {
+                "client_id": self._client_id,
+                "grant_type": "refresh_token",
+                "refresh_token": tokens.get("refresh_token", ""),
+            }
+        ).encode("utf-8")
+        request = Request(
+            self._refresh_url,
+            data=request_body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urlopen(request, timeout=self._upstream_timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            raw = exc.read().decode("utf-8", "replace") if exc.fp is not None else ""
+            try:
+                err_payload = json.loads(raw) if raw else {}
+            except ValueError:
+                err_payload = {"error": {"message": raw}}
+            raise _UpstreamRefreshError(exc.code, err_payload)
+        except URLError as exc:
+            raise _UpstreamRefreshError(
+                502, {"error": {"message": f"refresh upstream unreachable: {exc.reason}"}}
+            )
+
+        if not isinstance(payload, dict):
+            raise _UpstreamRefreshError(
+                502, {"error": {"message": "refresh upstream returned a non-object body"}}
+            )
+        new_access = payload.get("access_token")
+        if not isinstance(new_access, str) or not new_access:
+            raise _UpstreamRefreshError(
+                502, {"error": {"message": "refresh upstream returned no access_token"}}
+            )
+        # Only persist after the response validates, and only string fields, so a
+        # malformed 2xx body can never overwrite good token state with junk.
+        for field in ("id_token", "access_token", "refresh_token"):
+            value = payload.get(field)
+            if isinstance(value, str) and value:
+                tokens[field] = value
+        self._auth["tokens"] = tokens
+        self._auth["last_refresh"] = _utc_now_iso()
+        self._persist()
+
+    # -- storage -----------------------------------------------------------
+    def _load_auth(self) -> dict[str, Any]:
+        try:
+            data = json.loads(self._auth_json_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(
+                f"Failed to read Codex auth snapshot {self._auth_json_path}: {exc}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"Codex auth snapshot {self._auth_json_path} is not a JSON object"
+            )
+        return data
+
+    def _persist(self) -> None:
+        path = self._auth_json_path
+        tmp = path.with_name(path.name + ".tmp")
+        data = json.dumps(self._auth, indent=2) + "\n"
+        # Create the temp file owner-only (0o600) at creation time so the
+        # secret-bearing file is never momentarily readable by other users.
+        # os.replace preserves the source's permissions onto the final path.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(data)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+        tmp.replace(path)
+
+    @staticmethod
+    def _validate_chatgpt_auth(auth: dict[str, Any]) -> None:
+        tokens = auth.get("tokens")
+        access_token = tokens.get("access_token") if isinstance(tokens, dict) else None
+        refresh_token = tokens.get("refresh_token") if isinstance(tokens, dict) else None
+        if (
+            not isinstance(access_token, str)
+            or not access_token
+            or not isinstance(refresh_token, str)
+            or not refresh_token
+        ):
+            raise RuntimeError(
+                "Codex host auth is not a ChatGPT login (auth.json has no "
+                "tokens.refresh_token/access_token). Run `codex login` with a "
+                "ChatGPT subscription, or disable agent.codex.use_host_auth."
+            )
+
+
+class _BrokerServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, address, handler, broker: CodexTokenBroker):
+        super().__init__(address, handler)
+        self.broker = broker
+
+
+class _BrokerHandler(BaseHTTPRequestHandler):
+    server: _BrokerServer  # type: ignore[assignment]
+
+    def log_message(self, *_args) -> None:  # silence default stderr logging
+        pass
+
+    def _write_json(self, status: int, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self) -> None:
+        if self.path.split("?", 1)[0].rstrip("/") != REFRESH_PATH:
+            self._write_json(404, {"error": {"message": "not found"}})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            self._write_json(400, {"error": {"message": "invalid Content-Length"}})
+            return
+        if length < 0 or length > MAX_REQUEST_BYTES:
+            self._write_json(413, {"error": {"message": "request body too large"}})
+            return
+        raw = self.rfile.read(length) if length else b""
+        try:
+            body = json.loads(raw.decode("utf-8")) if raw else {}
+        except (ValueError, UnicodeDecodeError):
+            body = {}
+        if not isinstance(body, dict):
+            body = {}
+        status, payload = self.server.broker.handle_refresh(body)
+        self._write_json(status, payload)
+
+    def do_GET(self) -> None:
+        if self.path.rstrip("/") in ("/healthz", "/health"):
+            self._write_json(200, {"status": "ok"})
+        else:
+            self._write_json(404, {"error": {"message": "not found"}})

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -128,6 +128,7 @@ class ModelConfig(BaseModel):
     approval_policy: str = "never"
     sandbox: str = "danger-full-access"
     reasoning_effort: str | None = None
+    reasoning_summary: str | None = None
     service_tier: str | None = None
     context_length: int | None = None
     approval_mode: str | None = "none"

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -96,9 +96,30 @@ class APIConfig(BaseModel):
     wire_api: str = "responses"
 
 
+class CodexAuthConfig(BaseModel):
+    """Codex ChatGPT-subscription auth handling.
+
+    When ``use_host_auth`` is enabled, Teich seeds an ``auth.json`` snapshot
+    under ``auth_dir`` from the host's Codex login and runs a single in-process
+    token broker that owns the rotating OAuth refresh token. Each Codex
+    container gets its own seeded copy (with the refresh token replaced by a
+    per-run secret) and is pointed at the broker via
+    ``CODEX_REFRESH_TOKEN_URL_OVERRIDE``, so the broker is the sole caller of the
+    real refresh endpoint and concurrent containers cannot invalidate one
+    another. The broker reads and writes only the ``auth_dir`` copy; it never
+    touches the host ``~/.codex/auth.json``.
+    """
+    use_host_auth: bool = False
+    host_auth_file: Path | None = None
+    auth_dir: Path = Field(default=Path("./.teich/codex-auth"))
+    # Port for the host-side token broker. 0 = pick an ephemeral free port.
+    broker_port: int = Field(default=0, ge=0, le=65535)
+
+
 class AgentConfig(BaseModel):
     """Agent runtime selection."""
     provider: str = "codex"
+    codex: CodexAuthConfig = Field(default_factory=CodexAuthConfig)
 
 
 class ModelConfig(BaseModel):
@@ -107,6 +128,7 @@ class ModelConfig(BaseModel):
     approval_policy: str = "never"
     sandbox: str = "danger-full-access"
     reasoning_effort: str | None = None
+    service_tier: str | None = None
     context_length: int | None = None
     approval_mode: str | None = "none"
     pi_model_overrides: dict[str, object] = Field(default_factory=lambda: {"maxTokens": 131072})
@@ -242,6 +264,26 @@ class Config(BaseModel):
             raise ValueError(f"Prompts file not found: {v}")
         return v
 
+    @model_validator(mode="after")
+    def validate_codex_auth_dir(self) -> Config:
+        """Keep the Codex auth snapshot out of uploaded output directories."""
+        codex = self.agent.codex
+        if not codex.use_host_auth:
+            return self
+        auth_dir = codex.auth_dir.resolve()
+        for label, output_dir in (
+            ("traces_dir", self.output.traces_dir),
+            ("sandbox_dir", self.output.sandbox_dir),
+            ("failures_dir", self.output.failures_dir),
+        ):
+            if auth_dir.is_relative_to(output_dir.resolve()):
+                raise ValueError(
+                    f"agent.codex.auth_dir ({codex.auth_dir}) must not be inside "
+                    f"output.{label} ({output_dir}); it holds your Codex credentials "
+                    "and output directories are uploaded to Hugging Face."
+                )
+        return self
+
     @classmethod
     def from_yaml(cls, path: Path) -> Config:
         """Load config from YAML file.
@@ -310,6 +352,19 @@ class Config(BaseModel):
     def get_agent_provider(self) -> str:
         """Get active agent provider."""
         return self.agent.provider.strip().lower() or "codex"
+
+    def get_codex_host_auth_source(self) -> Path:
+        """Resolve the host Codex auth file to seed the shared snapshot from.
+
+        Honors an explicit ``host_auth_file`` override, then ``$CODEX_HOME``,
+        and finally the default ``~/.codex/auth.json``.
+        """
+        override = self.agent.codex.host_auth_file
+        if override is not None:
+            return Path(override).expanduser()
+        codex_home = os.environ.get("CODEX_HOME")
+        base = Path(codex_home).expanduser() if codex_home else Path.home() / ".codex"
+        return base / "auth.json"
 
     def get_dataset_tags(self) -> list[str]:
         """Get auto-generated dataset tags for README frontmatter and uploads."""

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -3359,6 +3359,13 @@ def _load_trace_file(trace_file: Path, *, skip_invalid_lines: bool = False) -> l
     return events
 
 
+def _is_codex_runtime_context(text: str) -> bool:
+    """Codex injects ``<environment_context>`` / ``<user_instructions>`` as leading
+    user messages. They are runtime context, not the user's prompt, so they must
+    not become the training example's prompt (which also breaks --resume matching)."""
+    return text.lstrip().startswith(("<environment_context>", "<user_instructions>"))
+
+
 def _convert_codex_trace_to_training_example(
     trace_file: Path,
     events: list[dict[str, Any]],
@@ -3442,6 +3449,10 @@ def _convert_codex_trace_to_training_example(
                 continue
             normalized_role = _normalize_role(role)
             content = _first_text_block(payload.get("content"))
+            # Only the leading wrappers (before the real prompt) are Codex
+            # runtime context; never drop user content mid-conversation.
+            if normalized_role == "user" and not prompt and _is_codex_runtime_context(content):
+                continue
             if normalized_role == "user" and content and not prompt:
                 prompt = content
             message: dict[str, Any] = {

--- a/src/teich/runner.py
+++ b/src/teich/runner.py
@@ -3212,6 +3212,8 @@ class ClaudeCodeRunner(ExternalCliRunner):
         permission_mode = self._permission_mode()
         if permission_mode:
             claude_command.extend(["--permission-mode", permission_mode])
+        if self.config.developer_instructions:
+            claude_command.extend(["--append-system-prompt", self.config.developer_instructions])
         if resume_session_id:
             claude_command.extend(["--resume", resume_session_id])
         elif continue_session:
@@ -3683,6 +3685,24 @@ class HermesRunner(ExternalCliRunner):
         }
         (home_dir / "config.yaml").write_text(json.dumps(hermes_config, indent=2), encoding="utf-8")
 
+    def _write_agents_md(self, workspace: Path) -> None:
+        """Inject developer_instructions via AGENTS.md, which Hermes auto-loads.
+
+        Hermes has no system-prompt flag; it auto-injects AGENTS.md from the
+        workspace (Teich does not pass --ignore-rules). Append to an existing
+        AGENTS.md so a cloned repo's own guidance is preserved.
+        """
+        instructions = self.config.developer_instructions
+        if not instructions or not instructions.strip():
+            return
+        block = instructions.strip() + "\n"
+        agents_md = workspace / "AGENTS.md"
+        if agents_md.exists():
+            existing = agents_md.read_text(encoding="utf-8").rstrip("\n")
+            agents_md.write_text(f"{existing}\n\n{block}", encoding="utf-8")
+        else:
+            agents_md.write_text(block, encoding="utf-8")
+
     @staticmethod
     def _decode_hermes_content(value: Any) -> Any:
         if isinstance(value, str) and value.startswith("\x00json:"):
@@ -3942,6 +3962,7 @@ class HermesRunner(ExternalCliRunner):
         try:
             workspace.mkdir(parents=True, exist_ok=True)
             self._write_hermes_runtime_config(home_dir)
+            self._write_agents_md(workspace)
             if len(turn_prompts) > 1:
                 self._start_tracked_container(
                     self._build_external_persistent_container_command(workspace, home_dir, container_name),
@@ -5312,6 +5333,8 @@ class PiRunner(DockerRuntimeRunner):
         api_key = self.config.get_api_key()
         if api_key and not configured_base_url:
             pi_command.extend(["--api-key", api_key])
+        if self.config.developer_instructions:
+            pi_command.extend(["--append-system-prompt", self.config.developer_instructions])
         if continue_session:
             pi_command.append("--continue")
         prompt_path = shlex.quote(f"{WORKSPACE_IN_CONTAINER}/{TEICH_PROMPT_FILE_NAME}")

--- a/src/teich/runner.py
+++ b/src/teich/runner.py
@@ -2165,6 +2165,10 @@ class CodexRunner(DockerRuntimeRunner):
             lines.append(
                 f"model_reasoning_effort = {self._toml_string(self.config.model.reasoning_effort)}"
             )
+        if self.config.model.reasoning_summary:
+            lines.append(
+                f"model_reasoning_summary = {self._toml_string(self.config.model.reasoning_summary)}"
+            )
         if self.config.model.service_tier:
             lines.append(
                 f"service_tier = {self._toml_string(self.config.model.service_tier)}"

--- a/src/teich/runner.py
+++ b/src/teich/runner.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
 from .config import PromptInput
 
+from .codex_auth_broker import CodexTokenBroker
+
 from .converter import (
     TEICH_AVAILABLE_TOOLS_CUSTOM_TYPE,
     convert_trace_to_training_example,
@@ -2006,6 +2008,11 @@ class DockerRuntimeRunner:
 class CodexRunner(DockerRuntimeRunner):
     """Manages Docker-based Codex sessions."""
 
+    def __init__(self, config: Config):
+        self._broker: CodexTokenBroker | None = None
+        self._broker_lock = threading.Lock()
+        super().__init__(config)
+
     @staticmethod
     def _toml_string(value: str) -> str:
         return json.dumps(value)
@@ -2082,6 +2089,70 @@ class CodexRunner(DockerRuntimeRunner):
         normalized = provider.strip().lower()
         return normalized in {"llama.cpp", "llama_cpp", "llamacpp"}
 
+    def _prepare_shared_host_auth(self) -> Path:
+        """Seed (once) and return the shared project ``auth.json`` snapshot.
+
+        Copies the host Codex login into ``agent.codex.auth_dir`` the first time,
+        and re-seeds only when the host file is newer than the snapshot, so a
+        token that Codex has already rotated in place is never clobbered by a
+        now-stale host file.
+        """
+        source = self.config.get_codex_host_auth_source()
+        if not source.exists():
+            raise RuntimeError(
+                f"Codex host auth file not found: {source}. Run `codex login` on the host "
+                "first, or disable agent.codex.use_host_auth."
+            )
+        shared_dir = self.config.agent.codex.auth_dir
+        shared_dir.mkdir(parents=True, exist_ok=True)
+        # The snapshot holds live credentials; keep it out of version control by
+        # default rather than relying on the user's project .gitignore.
+        gitignore = shared_dir / ".gitignore"
+        if not gitignore.exists():
+            gitignore.write_text("*\n", encoding="utf-8")
+        shared_auth = shared_dir / "auth.json"
+        if not shared_auth.exists() or source.stat().st_mtime > shared_auth.stat().st_mtime:
+            shutil.copyfile(source, shared_auth)
+            shared_auth.chmod(0o666)
+        return shared_auth
+
+    def _ensure_broker(self) -> CodexTokenBroker | None:
+        """Start (once per run) and return the host-side token broker.
+
+        Returns ``None`` when host auth is disabled. The broker seeds itself
+        from the ``auth_dir`` snapshot and owns the rotating refresh token for
+        the whole run; every container is pointed at it via the refresh-URL
+        override and seeded with its own copy.
+        """
+        if not self.config.agent.codex.use_host_auth:
+            return None
+        # run_all drives sessions from a thread pool, so guard creation: only one
+        # thread may build+start the single shared broker (double-checked lock).
+        if self._broker is None:
+            with self._broker_lock:
+                if self._broker is None:
+                    shared_auth = self._prepare_shared_host_auth()
+                    broker = CodexTokenBroker(
+                        shared_auth,
+                        port=self.config.agent.codex.broker_port,
+                    )
+                    broker.start()
+                    self._broker = broker
+        return self._broker
+
+    def _write_seeded_codex_auth(self, codex_home: Path, broker: CodexTokenBroker) -> None:
+        """Write a per-container ``auth.json`` (real tokens, secret refresh token)."""
+        auth_path = codex_home / "auth.json"
+        auth_path.write_text(
+            json.dumps(broker.seed_auth_json(), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        # 0o666 (matching _write_codex_config's config.toml) so the in-container
+        # `codex` user can read/rewrite the bind-mounted file regardless of how
+        # its uid maps to the host. This copy holds only a short-lived access
+        # token and the per-run broker secret -- never the real refresh token.
+        auth_path.chmod(0o666)
+
     def _write_codex_config(self, codex_home: Path) -> None:
         codex_home.mkdir(parents=True, exist_ok=True)
         codex_home.chmod(0o777)
@@ -2093,6 +2164,10 @@ class CodexRunner(DockerRuntimeRunner):
         if self.config.model.reasoning_effort:
             lines.append(
                 f"model_reasoning_effort = {self._toml_string(self.config.model.reasoning_effort)}"
+            )
+        if self.config.model.service_tier:
+            lines.append(
+                f"service_tier = {self._toml_string(self.config.model.service_tier)}"
             )
 
         for mcp in self.config.mcp_servers:
@@ -2263,6 +2338,7 @@ class CodexRunner(DockerRuntimeRunner):
         base_url, proxy_target = self._codex_base_url_and_proxy_target()
         provider_name = self.config.api.provider
         provider_env_key = self._provider_env_key(provider_name)
+        broker = self._ensure_broker()
         cmd = [
             "docker",
             "run",
@@ -2283,11 +2359,18 @@ class CodexRunner(DockerRuntimeRunner):
             "-w",
             WORKSPACE_IN_CONTAINER,
         ]
-        if proxy_target or (configured_base_url and base_url != configured_base_url):
+        broker_active = broker is not None
+        if proxy_target or broker_active or (configured_base_url and base_url != configured_base_url):
             cmd.extend([
                 "--add-host",
                 "host.docker.internal:host-gateway",
             ])
+        if broker is not None:
+            # Codex stays native (talks to chatgpt.com directly) but every
+            # token refresh is redirected to the host-side broker, which is the
+            # sole owner of the rotating refresh token. Codex is seeded with its
+            # own auth.json copy in CODEX_HOME (see _write_seeded_codex_auth).
+            cmd.extend(["-e", f"CODEX_REFRESH_TOKEN_URL_OVERRIDE={broker.override_url}"])
         if proxy_target:
             cmd.extend(
                 [
@@ -2297,7 +2380,7 @@ class CodexRunner(DockerRuntimeRunner):
                     f"TEICH_LOCAL_PROVIDER_PORT={self._local_provider_default_port(provider_name)}",
                 ]
             )
-        if api_key:
+        if api_key and not broker_active:
             cmd.extend(["-e", f"{provider_env_key}={api_key}"])
         return cmd, proxy_target
 
@@ -2476,6 +2559,9 @@ class CodexRunner(DockerRuntimeRunner):
 
         try:
             self._write_codex_config(codex_home)
+            broker = self._ensure_broker()
+            if broker is not None:
+                self._write_seeded_codex_auth(codex_home, broker)
             if self._local_provider_proxy_target(self.config.api.provider, self.config.get_base_url()):
                 self._write_local_provider_proxy(codex_home)
             existing_sessions = {path.resolve() for path in self._list_session_files(codex_home)}
@@ -2609,12 +2695,17 @@ class CodexRunner(DockerRuntimeRunner):
         prompt_inputs: list[PromptInput] | None = None,
         resume: bool = False,
     ) -> list[Path]:
-        return super().run_all(
-            max_concurrency=max_concurrency,
-            progress_callback=progress_callback,
-            prompt_inputs=prompt_inputs,
-            resume=resume,
-        )
+        try:
+            return super().run_all(
+                max_concurrency=max_concurrency,
+                progress_callback=progress_callback,
+                prompt_inputs=prompt_inputs,
+                resume=resume,
+            )
+        finally:
+            if self._broker is not None:
+                self._broker.stop()
+                self._broker = None
 
 
 class ExternalCliRunner(DockerRuntimeRunner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,6 +218,74 @@ openai_api_key: sk-test
         assert not (output_dir / "tools.json").exists()
 
 
+def test_generate_warns_on_host_auth_concurrency(tmp_path: Path):
+    """Host-auth runs warn about host re-login and concurrent-refresh races."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(f"""
+agent:
+  provider: codex
+  codex:
+    use_host_auth: true
+model:
+  model: gpt-5.5
+prompts:
+  - Build a todo app
+  - Another prompt
+output:
+  traces_dir: {tmp_path}/output
+max_concurrency: 2
+""")
+
+    with patch('teich.cli.CodexRunner') as mock_runner:
+        mock_instance = MagicMock()
+        mock_instance.run_all.return_value = [tmp_path / "output/session1.jsonl"]
+        mock_runner.return_value = mock_instance
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "session1.jsonl").write_text(
+            '{"type":"session_meta","payload":{"id":"session1"}}\n'
+            '{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Build a todo app"}]}}\n'
+        )
+
+        result = runner.invoke(app, ["generate", "-c", str(config_file)])
+
+    assert result.exit_code == 0
+    assert "host Codex login" in result.output
+    assert "concurren" in result.output.lower()
+
+
+def test_generate_no_host_auth_warning_when_disabled(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(f"""
+agent:
+  provider: codex
+model:
+  model: codex-mini-latest
+prompts:
+  - Build a todo app
+output:
+  traces_dir: {tmp_path}/output
+openai_api_key: sk-test
+max_concurrency: 2
+""")
+
+    with patch('teich.cli.CodexRunner') as mock_runner:
+        mock_instance = MagicMock()
+        mock_instance.run_all.return_value = [tmp_path / "output/session1.jsonl"]
+        mock_runner.return_value = mock_instance
+        output_dir = tmp_path / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "session1.jsonl").write_text(
+            '{"type":"session_meta","payload":{"id":"session1"}}\n'
+            '{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Build a todo app"}]}}\n'
+        )
+        result = runner.invoke(app, ["generate", "-c", str(config_file)])
+
+    assert result.exit_code == 0
+    assert "host Codex login" not in result.output
+
+
 def test_generate_command_success_chat(tmp_path: Path):
     config_file = tmp_path / "config.yaml"
     config_file.write_text(f"""

--- a/tests/test_codex_auth_broker.py
+++ b/tests/test_codex_auth_broker.py
@@ -1,0 +1,226 @@
+"""Hermetic tests for the Codex host-auth token broker.
+
+These tests use fake JWTs and a local fake OAuth upstream; they never touch the
+network, Docker, or any real auth.json.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.request import urlopen
+
+import pytest
+
+from teich.codex_auth_broker import CodexTokenBroker, _decode_jwt_exp
+
+
+def _make_jwt(exp_offset_seconds: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = json.dumps({"exp": int(time.time()) + exp_offset_seconds}).encode()
+    body = base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+    return f"{header}.{body}.sig"
+
+
+def _write_auth(path: Path, *, access_exp_offset: int = 3600, refresh_token: str = "real-refresh-0") -> None:
+    auth = {
+        "tokens": {
+            "id_token": _make_jwt(99_999),
+            "access_token": _make_jwt(access_exp_offset),
+            "refresh_token": refresh_token,
+            "account_id": "acct-123",
+        },
+        "last_refresh": "2026-06-01T00:00:00+00:00",
+    }
+    path.write_text(json.dumps(auth), encoding="utf-8")
+
+
+class _UpstreamHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_a):  # noqa: D401 - silence test server logging
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b""
+        self.server.calls.append(json.loads(raw.decode("utf-8")))  # type: ignore[attr-defined]
+        if self.server.delay:  # type: ignore[attr-defined]
+            time.sleep(self.server.delay)  # type: ignore[attr-defined]
+        data = json.dumps(self.server.response).encode("utf-8")  # type: ignore[attr-defined]
+        self.send_response(self.server.status)  # type: ignore[attr-defined]
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class _Upstream(ThreadingHTTPServer):
+    daemon_threads = True
+
+
+@pytest.fixture
+def upstream():
+    server = _Upstream(("127.0.0.1", 0), _UpstreamHandler)
+    server.calls = []
+    server.status = 200
+    server.delay = 0.0
+    server.response = {
+        "id_token": _make_jwt(99_999),
+        "access_token": _make_jwt(3600),
+        "refresh_token": "real-refresh-rotated",
+    }
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}/oauth/token"
+    try:
+        yield server, url
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _broker(auth_path: Path, url: str, **kwargs) -> CodexTokenBroker:
+    return CodexTokenBroker(auth_path, refresh_url=url, client_id="test-client", **kwargs)
+
+
+def test_decode_jwt_exp_roundtrip():
+    token = _make_jwt(1000)
+    exp = _decode_jwt_exp(token)
+    assert exp is not None and abs(exp - (time.time() + 1000)) < 5
+    assert _decode_jwt_exp("not-a-jwt") is None
+
+
+def test_rejects_non_chatgpt_auth(tmp_path):
+    path = tmp_path / "auth.json"
+    path.write_text(json.dumps({"OPENAI_API_KEY": "sk-x"}), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="not a ChatGPT login"):
+        _broker(path, "http://127.0.0.1:1/oauth/token")
+
+
+def test_wrong_secret_is_rejected(tmp_path, upstream):
+    _server, url = upstream
+    path = tmp_path / "auth.json"
+    _write_auth(path)
+    broker = _broker(path, url)
+    status, payload = broker.handle_refresh({"refresh_token": "wrong"})
+    assert status == 401
+    assert payload["error"]["code"] == "invalid_grant"
+
+
+def test_valid_token_served_without_rotation(tmp_path, upstream):
+    server, url = upstream
+    path = tmp_path / "auth.json"
+    _write_auth(path, access_exp_offset=3600)  # far from expiry
+    broker = _broker(path, url)
+    original_access = json.loads(path.read_text())["tokens"]["access_token"]
+
+    status, payload = broker.handle_refresh({"refresh_token": broker.secret})
+
+    assert status == 200
+    assert payload["access_token"] == original_access
+    assert payload["refresh_token"] == broker.secret  # never the real one
+    assert server.calls == []  # no upstream rotation
+
+
+def test_near_expiry_triggers_single_rotation(tmp_path, upstream):
+    server, url = upstream
+    path = tmp_path / "auth.json"
+    _write_auth(path, access_exp_offset=60)  # inside the 6-min window
+    broker = _broker(path, url)
+
+    status, payload = broker.handle_refresh({"refresh_token": broker.secret})
+
+    assert status == 200
+    assert payload["access_token"] == server.response["access_token"]
+    assert len(server.calls) == 1
+    # Upstream received the REAL refresh token, not the secret.
+    assert server.calls[0]["refresh_token"] == "real-refresh-0"
+    assert server.calls[0]["client_id"] == "test-client"
+    # Rotation persisted to the auth_dir copy.
+    persisted = json.loads(path.read_text())
+    assert persisted["tokens"]["access_token"] == server.response["access_token"]
+    assert persisted["tokens"]["refresh_token"] == "real-refresh-rotated"
+
+
+def test_concurrent_refresh_is_single_flight(tmp_path, upstream):
+    server, url = upstream
+    server.delay = 0.3
+    path = tmp_path / "auth.json"
+    _write_auth(path, access_exp_offset=60)
+    broker = _broker(path, url)
+
+    results: list[tuple[int, dict]] = []
+    lock = threading.Lock()
+
+    def worker():
+        out = broker.handle_refresh({"refresh_token": broker.secret})
+        with lock:
+            results.append(out)
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 6  # every worker completed and recorded a result
+    assert len(server.calls) == 1  # only one real rotation
+    assert all(status == 200 for status, _ in results)
+    tokens_returned = {payload["access_token"] for _, payload in results}
+    assert tokens_returned == {server.response["access_token"]}
+
+
+def test_upstream_failure_is_relayed(tmp_path, upstream):
+    server, url = upstream
+    server.status = 400
+    server.response = {"error": {"code": "refresh_token_reused", "message": "reused"}}
+    path = tmp_path / "auth.json"
+    _write_auth(path, access_exp_offset=60)
+    broker = _broker(path, url)
+
+    status, payload = broker.handle_refresh({"refresh_token": broker.secret})
+
+    assert status == 400
+    assert payload["error"]["code"] == "refresh_token_reused"
+
+
+def test_seed_auth_json_hides_real_refresh_token(tmp_path, upstream):
+    _server, url = upstream
+    path = tmp_path / "auth.json"
+    _write_auth(path, refresh_token="real-refresh-secret")
+    broker = _broker(path, url)
+
+    seed = broker.seed_auth_json()
+
+    assert seed["tokens"]["refresh_token"] == broker.secret
+    assert seed["tokens"]["refresh_token"] != "real-refresh-secret"
+    assert seed["tokens"]["access_token"] == json.loads(path.read_text())["tokens"]["access_token"]
+    assert seed["tokens"]["account_id"] == "acct-123"
+    # The on-disk copy still holds the real refresh token (broker did not mutate it).
+    assert json.loads(path.read_text())["tokens"]["refresh_token"] == "real-refresh-secret"
+
+
+def test_http_server_roundtrip_and_override_url(tmp_path, upstream):
+    _server, url = upstream
+    path = tmp_path / "auth.json"
+    _write_auth(path, access_exp_offset=3600)
+    broker = _broker(path, url, host="127.0.0.1")
+    broker.start()
+    try:
+        assert broker.port is not None
+        assert broker.override_url == f"http://host.docker.internal:{broker.port}/oauth/token"
+        # Hit the broker's own HTTP endpoint the way Codex would.
+        body = json.dumps(
+            {"client_id": "app", "grant_type": "refresh_token", "refresh_token": broker.secret}
+        ).encode("utf-8")
+        endpoint = f"http://127.0.0.1:{broker.port}/oauth/token"
+        with urlopen(endpoint, data=body, timeout=5) as resp:  # noqa: S310 - localhost test
+            assert resp.status == 200
+            payload = json.loads(resp.read().decode("utf-8"))
+        assert payload["refresh_token"] == broker.secret
+    finally:
+        broker.stop()
+        assert broker.port is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -397,6 +397,17 @@ def test_model_service_tier_is_free_string_passthrough():
     assert ModelConfig(service_tier="flex").service_tier == "flex"
 
 
+def test_model_reasoning_summary_defaults_to_none():
+    """Reasoning summaries use Codex's default unless explicitly set."""
+    assert Config().model.reasoning_summary is None
+
+
+def test_model_reasoning_summary_is_free_string_passthrough():
+    """reasoning_summary accepts auto/concise/detailed/none without an enum."""
+    assert ModelConfig(reasoning_summary="detailed").reasoning_summary == "detailed"
+    assert ModelConfig(reasoning_summary="concise").reasoning_summary == "concise"
+
+
 def test_codex_auth_config_defaults():
     """Codex host-auth is off by default with a project-local auth dir."""
     codex = Config().agent.codex

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -386,6 +386,85 @@ api:
         Config.from_yaml(config_file)
 
 
+def test_model_service_tier_defaults_to_none():
+    """Fast mode is opt-in: service_tier is unset by default."""
+    assert Config().model.service_tier is None
+
+
+def test_model_service_tier_is_free_string_passthrough():
+    """service_tier accepts arbitrary tiers (fast/flex/priority) without an enum."""
+    assert ModelConfig(service_tier="fast").service_tier == "fast"
+    assert ModelConfig(service_tier="flex").service_tier == "flex"
+
+
+def test_codex_auth_config_defaults():
+    """Codex host-auth is off by default with a project-local auth dir."""
+    codex = Config().agent.codex
+    assert codex.use_host_auth is False
+    assert codex.host_auth_file is None
+    assert codex.auth_dir == Path("./.teich/codex-auth")
+
+
+def test_codex_auth_config_from_yaml(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("TEICH_MODEL", raising=False)
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+agent:
+  provider: codex
+  codex:
+    use_host_auth: true
+    host_auth_file: ~/.codex/auth.json
+    auth_dir: ./.teich/codex-auth
+model:
+  model: gpt-5.5
+  service_tier: fast
+"""
+    )
+    config = Config.from_yaml(config_file)
+    assert config.agent.codex.use_host_auth is True
+    assert config.agent.codex.host_auth_file == Path("~/.codex/auth.json")
+    assert config.agent.codex.auth_dir == Path("./.teich/codex-auth")
+    assert config.model.service_tier == "fast"
+
+
+def test_codex_auth_dir_under_output_rejected_when_enabled():
+    """The auth snapshot must never live under uploaded output dirs."""
+    with pytest.raises(ValueError, match="auth_dir"):
+        Config(
+            agent={"provider": "codex", "codex": {"use_host_auth": True, "auth_dir": "./output/secrets"}},
+            output={"traces_dir": "./output"},
+        )
+
+
+def test_codex_auth_dir_under_output_allowed_when_disabled():
+    """When host-auth is off the snapshot dir is never used, so don't over-validate."""
+    config = Config(
+        agent={"provider": "codex", "codex": {"use_host_auth": False, "auth_dir": "./output/secrets"}},
+        output={"traces_dir": "./output"},
+    )
+    assert config.agent.codex.auth_dir == Path("./output/secrets")
+
+
+def test_codex_host_auth_source_prefers_explicit_override(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    override = tmp_path / "creds" / "auth.json"
+    config = Config(agent={"provider": "codex", "codex": {"host_auth_file": str(override)}})
+    assert config.get_codex_host_auth_source() == override
+
+
+def test_codex_host_auth_source_uses_codex_home_env(monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", "/custom/codex")
+    config = Config(agent={"provider": "codex"})
+    assert config.get_codex_host_auth_source() == Path("/custom/codex/auth.json")
+
+
+def test_codex_host_auth_source_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    config = Config(agent={"provider": "codex"})
+    assert config.get_codex_host_auth_source() == Path.home() / ".codex" / "auth.json"
+
+
 def test_mcp_config():
     """Test MCP server configuration."""
     mcp = MCPConfig(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2873,3 +2873,32 @@ def test_convert_pi_trace_uses_thinking_blocks_and_tool_results(tmp_path: Path):
     assert {"bash", "read", "write", "edit"}.issubset(tool_names)
     bash_tool = next(tool for tool in example.tools if tool["function"]["name"] == "bash")
     assert bash_tool["function"]["parameters"]["properties"]["command"] == {"type": "string"}
+
+
+def test_codex_skips_injected_runtime_context(tmp_path: Path):
+    """Codex injects <environment_context>/<user_instructions> as leading user
+    messages; they must not become the prompt (which also breaks --resume)."""
+    trace_file = tmp_path / "codex-session.jsonl"
+    events = [
+        {"type": "session_meta", "payload": {"id": "codex-session"}},
+        {"type": "response_item", "payload": {"type": "message", "role": "user",
+            "content": [{"type": "input_text", "text": "<environment_context>\n  <cwd>/workspace</cwd>\n</environment_context>"}]}},
+        {"type": "response_item", "payload": {"type": "message", "role": "user",
+            "content": [{"type": "input_text", "text": "<user_instructions>\n  Be concise.\n</user_instructions>"}]}},
+        {"type": "response_item", "payload": {"type": "message", "role": "user",
+            "content": [{"type": "input_text", "text": "make me a delivery routing dashboard"}]}},
+        {"type": "response_item", "payload": {"type": "message", "role": "assistant",
+            "content": [{"type": "output_text", "text": "Done."}]}},
+    ]
+    trace_file.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    example = convert_trace_to_training_example(trace_file)
+
+    assert example.prompt == "make me a delivery routing dashboard"
+    user_contents = [m["content"] for m in example.messages if m["role"] == "user"]
+    assert user_contents == ["make me a delivery routing dashboard"]
+    assert not any(
+        tag in (m.get("content") or "")
+        for m in example.messages
+        for tag in ("<environment_context>", "<user_instructions>")
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -346,6 +346,27 @@ def test_codex_config_omits_service_tier_when_unset(tmp_path: Path):
     assert "service_tier" not in content
 
 
+def test_codex_config_writes_reasoning_summary(tmp_path: Path):
+    """reasoning_summary is written to config.toml as model_reasoning_summary when set."""
+    config = Config(model=ModelConfig(model="gpt-5.5", reasoning_summary="detailed"))
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    codex_home = tmp_path / ".codex"
+    runner._write_codex_config(codex_home)
+    content = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert 'model_reasoning_summary = "detailed"' in content
+
+
+def test_codex_config_omits_reasoning_summary_when_unset(tmp_path: Path):
+    config = Config(model=ModelConfig(model="gpt-5.5"))
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    codex_home = tmp_path / ".codex"
+    runner._write_codex_config(codex_home)
+    content = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert "model_reasoning_summary" not in content
+
+
 def _codex_host_auth_config(tmp_path: Path) -> tuple[Config, Path]:
     host_auth = tmp_path / "host" / "auth.json"
     host_auth.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1693,6 +1693,93 @@ def test_hermes_runner_writes_custom_endpoint_runtime_config(tmp_path: Path):
     ]
 
 
+_DEV_INSTRUCTIONS = "Think out loud and explain your reasoning."
+
+
+def _dev_instructions_config(provider: str, tmp_path: Path) -> Config:
+    return Config(
+        agent={"provider": provider},
+        output={"traces_dir": tmp_path / "output", "sandbox_dir": tmp_path / "sandbox"},
+        developer_instructions=_DEV_INSTRUCTIONS,
+    )
+
+
+def _plain_config(provider: str, tmp_path: Path) -> Config:
+    return Config(
+        agent={"provider": provider},
+        output={"traces_dir": tmp_path / "output", "sandbox_dir": tmp_path / "sandbox"},
+    )
+
+
+def test_claude_appends_developer_instructions_as_system_prompt(tmp_path: Path):
+    with patch.object(ClaudeCodeRunner, "_ensure_image"):
+        runner = ClaudeCodeRunner(_dev_instructions_config("claude-code", tmp_path))
+    command = runner._build_shell_command()
+    assert "--append-system-prompt" in command
+    assert _DEV_INSTRUCTIONS in command
+
+
+def test_claude_omits_system_prompt_without_developer_instructions(tmp_path: Path):
+    with patch.object(ClaudeCodeRunner, "_ensure_image"):
+        runner = ClaudeCodeRunner(_plain_config("claude-code", tmp_path))
+    assert "--append-system-prompt" not in runner._build_shell_command()
+
+
+def test_pi_appends_developer_instructions_as_system_prompt(tmp_path: Path):
+    with patch.object(PiRunner, "_ensure_image"):
+        runner = PiRunner(_dev_instructions_config("pi", tmp_path))
+    joined = " ".join(runner._build_pi_agent_command())
+    assert "--append-system-prompt" in joined
+    assert _DEV_INSTRUCTIONS in joined
+
+
+def test_pi_omits_system_prompt_without_developer_instructions(tmp_path: Path):
+    with patch.object(PiRunner, "_ensure_image"):
+        runner = PiRunner(_plain_config("pi", tmp_path))
+    assert "--append-system-prompt" not in " ".join(runner._build_pi_agent_command())
+
+
+def test_hermes_writes_developer_instructions_to_agents_md(tmp_path: Path):
+    with patch.object(HermesRunner, "_ensure_image"):
+        runner = HermesRunner(_dev_instructions_config("hermes", tmp_path))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    runner._write_agents_md(workspace)
+    agents_md = workspace / "AGENTS.md"
+    assert agents_md.exists()
+    assert _DEV_INSTRUCTIONS in agents_md.read_text(encoding="utf-8")
+
+
+def test_hermes_appends_to_existing_agents_md(tmp_path: Path):
+    with patch.object(HermesRunner, "_ensure_image"):
+        runner = HermesRunner(_dev_instructions_config("hermes", tmp_path))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text("# Existing project rules\n", encoding="utf-8")
+    runner._write_agents_md(workspace)
+    content = (workspace / "AGENTS.md").read_text(encoding="utf-8")
+    assert "# Existing project rules" in content
+    assert _DEV_INSTRUCTIONS in content
+
+
+def test_hermes_no_agents_md_without_developer_instructions(tmp_path: Path):
+    with patch.object(HermesRunner, "_ensure_image"):
+        runner = HermesRunner(_plain_config("hermes", tmp_path))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    runner._write_agents_md(workspace)
+    assert not (workspace / "AGENTS.md").exists()
+
+
+def test_codex_writes_developer_instructions_to_config(tmp_path: Path):
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(_dev_instructions_config("codex", tmp_path))
+    codex_home = tmp_path / ".codex"
+    runner._write_codex_config(codex_home)
+    content = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert f'developer_instructions = "{_DEV_INSTRUCTIONS}"' in content
+
+
 def test_external_runner_decodes_subprocess_output_as_utf8(tmp_path: Path):
     config = Config(
         agent={"provider": "hermes"},

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -325,6 +325,187 @@ def test_codex_config_setup(tmp_path: Path):
         assert oct(config_file.stat().st_mode & 0o777) == "0o666"
 
 
+def test_codex_config_writes_service_tier(tmp_path: Path):
+    """Fast mode is written to config.toml as service_tier when set."""
+    config = Config(model=ModelConfig(model="gpt-5.5", service_tier="fast"))
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    codex_home = tmp_path / ".codex"
+    runner._write_codex_config(codex_home)
+    content = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert 'service_tier = "fast"' in content
+
+
+def test_codex_config_omits_service_tier_when_unset(tmp_path: Path):
+    config = Config(model=ModelConfig(model="gpt-5.5"))
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    codex_home = tmp_path / ".codex"
+    runner._write_codex_config(codex_home)
+    content = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert "service_tier" not in content
+
+
+def _codex_host_auth_config(tmp_path: Path) -> tuple[Config, Path]:
+    host_auth = tmp_path / "host" / "auth.json"
+    host_auth.parent.mkdir(parents=True, exist_ok=True)
+    host_auth.write_text('{"tokens":{"refresh_token":"R0"}}', encoding="utf-8")
+    config = Config(
+        agent={
+            "provider": "codex",
+            "codex": {
+                "use_host_auth": True,
+                "host_auth_file": str(host_auth),
+                "auth_dir": str(tmp_path / "project" / ".teich" / "codex-auth"),
+            },
+        },
+    )
+    return config, host_auth
+
+
+def test_codex_prepare_shared_host_auth_seeds_from_host(tmp_path: Path):
+    config, host_auth = _codex_host_auth_config(tmp_path)
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    shared = runner._prepare_shared_host_auth()
+    assert shared == (tmp_path / "project" / ".teich" / "codex-auth" / "auth.json")
+    assert shared.read_text(encoding="utf-8") == '{"tokens":{"refresh_token":"R0"}}'
+    if _filesystem_preserves_chmod(tmp_path):
+        assert oct(shared.stat().st_mode & 0o777) == "0o666"
+
+
+def test_codex_prepare_shared_host_auth_gitignores_credentials(tmp_path: Path):
+    """The credential snapshot dir is gitignored by default, not just by docs."""
+    config, _ = _codex_host_auth_config(tmp_path)
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    shared = runner._prepare_shared_host_auth()
+    gitignore = shared.parent / ".gitignore"
+    assert gitignore.exists()
+    assert "*" in gitignore.read_text(encoding="utf-8").split()
+
+
+def test_codex_prepare_shared_host_auth_preserves_rotated_token(tmp_path: Path):
+    """A refreshed (rotated) shared token must not be clobbered by the stale host file."""
+    config, host_auth = _codex_host_auth_config(tmp_path)
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    shared = runner._prepare_shared_host_auth()
+    # Codex refreshes in place: shared advances to R1, newer than the host file.
+    shared.write_text('{"tokens":{"refresh_token":"R1"}}', encoding="utf-8")
+    os.utime(shared, (time.time() + 10, time.time() + 10))
+    again = runner._prepare_shared_host_auth()
+    assert again.read_text(encoding="utf-8") == '{"tokens":{"refresh_token":"R1"}}'
+
+
+def test_codex_prepare_shared_host_auth_reseeds_when_host_newer(tmp_path: Path):
+    """A fresh host login (newer mtime) re-seeds the shared snapshot."""
+    config, host_auth = _codex_host_auth_config(tmp_path)
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    runner._prepare_shared_host_auth()
+    host_auth.write_text('{"tokens":{"refresh_token":"R_new"}}', encoding="utf-8")
+    os.utime(host_auth, (time.time() + 10, time.time() + 10))
+    shared = runner._prepare_shared_host_auth()
+    assert shared.read_text(encoding="utf-8") == '{"tokens":{"refresh_token":"R_new"}}'
+
+
+def test_codex_prepare_shared_host_auth_errors_when_missing(tmp_path: Path):
+    config = Config(
+        agent={
+            "provider": "codex",
+            "codex": {"use_host_auth": True, "host_auth_file": str(tmp_path / "missing.json")},
+        },
+    )
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    with pytest.raises(RuntimeError, match="codex login"):
+        runner._prepare_shared_host_auth()
+
+
+def _codex_host_auth_config_with_tokens(tmp_path: Path) -> Config:
+    """Host-auth config whose snapshot is a complete ChatGPT login (the broker
+    validates that both an access and a refresh token are present)."""
+    host_auth = tmp_path / "host" / "auth.json"
+    host_auth.parent.mkdir(parents=True, exist_ok=True)
+    host_auth.write_text(
+        '{"tokens":{"access_token":"A0","refresh_token":"R0","account_id":"acct"}}',
+        encoding="utf-8",
+    )
+    return Config(
+        agent={
+            "provider": "codex",
+            "codex": {
+                "use_host_auth": True,
+                "host_auth_file": str(host_auth),
+                "auth_dir": str(tmp_path / "project" / ".teich" / "codex-auth"),
+            },
+        },
+    )
+
+
+def test_codex_command_uses_broker_and_suppresses_api_key(tmp_path: Path, monkeypatch):
+    """With host-auth on, point Codex at the broker (refresh override + host-gateway),
+    mount no auth.json, and pass no API key env (even an ambient one)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-ambient-should-not-leak")
+    config = _codex_host_auth_config_with_tokens(tmp_path)
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    try:
+        cmd = runner._build_codex_command(
+            "Build app",
+            workspace=tmp_path / "ws",
+            codex_home=tmp_path / "ch",
+            container_name="teich-codex-x",
+        )
+        override = next(
+            part for part in cmd if part.startswith("CODEX_REFRESH_TOKEN_URL_OVERRIDE=")
+        )
+        assert override.startswith("CODEX_REFRESH_TOKEN_URL_OVERRIDE=http://host.docker.internal:")
+        assert override.endswith("/oauth/token")
+        assert "host.docker.internal:host-gateway" in cmd
+        # No auth.json bind-mount, and no API key env (broker owns the real token).
+        assert not any(":/home/codex/.codex/auth.json" in part for part in cmd)
+        assert not any(part.startswith("OPENAI_API_KEY=") for part in cmd)
+    finally:
+        if runner._broker is not None:
+            runner._broker.stop()
+
+
+def test_codex_write_seeded_auth_hides_real_refresh_token(tmp_path: Path):
+    """Each container's seeded auth.json carries real tokens but a secret refresh token."""
+    config = _codex_host_auth_config_with_tokens(tmp_path)
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    try:
+        broker = runner._ensure_broker()
+        assert broker is not None
+        codex_home = tmp_path / "ch"
+        codex_home.mkdir()
+        runner._write_seeded_codex_auth(codex_home, broker)
+        seeded = json.loads((codex_home / "auth.json").read_text(encoding="utf-8"))
+        assert seeded["tokens"]["access_token"] == "A0"
+        assert seeded["tokens"]["refresh_token"] == broker.secret
+        assert seeded["tokens"]["refresh_token"] != "R0"
+    finally:
+        if runner._broker is not None:
+            runner._broker.stop()
+
+
+def test_codex_command_without_host_auth_still_passes_api_key(tmp_path: Path):
+    config = Config(model=ModelConfig(model="o4-mini"), openai_api_key="sk-test123")
+    with patch.object(CodexRunner, "_ensure_image"):
+        runner = CodexRunner(config)
+    cmd = runner._build_codex_command(
+        "Build app",
+        workspace=tmp_path / "ws",
+        codex_home=tmp_path / "ch",
+        container_name="teich-codex-x",
+    )
+    assert "OPENAI_API_KEY=sk-test123" in cmd
+    assert not any(":/home/codex/.codex/auth.json" in part for part in cmd)
+
+
 def test_run_session_command_generation():
     """Test that codex exec command is generated correctly."""
     config = Config(


### PR DESCRIPTION
## Overview

Four small, opt-in improvements to the Codex runner — ChatGPT-subscription host auth, fast mode, two `config.toml` passthroughs — plus one cross-provider config knob and a trace-conversion bug fix. All defaults are unchanged: existing API-key Codex runs and every other provider behave exactly as before, and there are no new runtime dependencies.

## What's included

### 1. Codex ChatGPT-subscription host auth + fast mode

Let the Codex runner use a ChatGPT subscription instead of an API key, and expose Codex fast mode.

- `agent.codex.use_host_auth` seeds one `auth.json` snapshot from your host login (`$CODEX_HOME/auth.json` or `~/.codex/auth.json`) into `auth_dir`, then runs a small **in-process token broker** that owns the rotating OAuth refresh token for the whole run.
- Each Codex container stays native and is pointed at the broker via `CODEX_REFRESH_TOKEN_URL_OVERRIDE`, seeded with its own `auth.json` whose `refresh_token` is a per-run secret. The broker is the sole caller of the real refresh endpoint and single-flights rotation, so concurrent containers can't invalidate one another's tokens. The durable refresh token never enters a container, and the broker only ever reads/writes the `auth_dir` copy — never the host `~/.codex/auth.json`.
- When host auth is on, no `*_API_KEY` env is passed into the container (even an ambient `OPENAI_API_KEY`).
- `model.service_tier` is written to `config.toml`; set it to `"fast"` for Codex fast mode (needs subscription auth plus a supported model such as gpt-5.5/5.4).
- Safety: config refuses to place `auth_dir` under the uploaded output/sandbox/failures dirs and drops a `.gitignore` into it; the CLI warns that the host `codex` login is invalidated after the first rotation.
- The broker is pure standard library (`http.server` + `urllib`).

### 2. Codex `reasoning_summary` passthrough

Expose `model.reasoning_summary`, written verbatim to `config.toml` as `model_reasoning_summary` (`auto | concise | detailed | none`, free-form passthrough, default unset). Codex's default can emit empty reasoning summaries (`summary: []`); `"detailed"` captures richer summaries in traces. Mirrors the existing `reasoning_effort` / `service_tier` passthroughs.

### 3. `developer_instructions` across all runners

`developer_instructions` was Codex-only. This injects it into every runner via each agent's native *additive* mechanism, so it augments rather than replaces the built-in base prompt:

- claude-code, pi: `--append-system-prompt`
- hermes: auto-loaded `AGENTS.md` (appended to any existing one from a cloned repo)
- codex: unchanged (`config.toml`), now with test coverage

Handy for nudging chain-of-thought narration into traces across providers.

### 4. Skip Codex's injected runtime context in trace conversion

Codex prepends `<environment_context>` / `<user_instructions>` as leading user messages. The converter took the first user message as the training example's prompt, so the prompt became that runtime boilerplate and the real task was demoted to a follow-up turn — corrupting Codex training rows and breaking `--resume` (completed prompts never matched). On a real 282-prompt run, resume detected 0 of 56 completed rollouts before the fix and 37 after. Only the leading wrappers (before the real prompt is seen) are skipped, so a tag appearing mid-conversation is never dropped.

## Testing

- New and expanded unit tests cover the broker, host-auth config + CLI messaging, `reasoning_summary`, `developer_instructions` across all four runners, and the converter regression. The suite passes without Docker.
- `ruff check` is clean.

## Compatibility

Everything is opt-in and defaults are unchanged; API-key Codex runs and all other providers are unaffected. No new runtime dependencies.
