### PR TITLE
Add bench generation mode with Harbor and SWE‑bench backends

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -144,6 +144,11 @@ output:
   # These files are excluded from resume detection, conversion, README generation, and uploads.
   failures_dir: ./failures
 
+  # Harbor bench-mode intermediates (downloaded sources, raw trials, normalized sessions).
+  # Defaults to a `bench` dir beside traces_dir (parallel to sandbox/failures), never inside
+  # the dataset. Set a path to override.
+  bench_dir: null
+
   # Used in the generated trace README.
   pretty_name: "My Agent Traces"
 
@@ -153,6 +158,23 @@ publish:
   repo_id: null
   hf_token: null
   private: false
+
+# Benchmark mode (`teich generate --mode bench`). Each source is run by a backend selected
+# by `type`: `harbor` (the harbor package; needs teich[harbor], Python 3.12+) or `swe-bench`
+# (the swebench package; needs teich[swe]). teich runs the configured agent on each task/
+# instance, harvests the plain native trace into output/{passed,failed,borderline}/, and
+# writes scores + provenance to output/metadata/<stem>.json. Intermediates live under
+# output.bench_dir (a sibling `bench` dir by default), outside the dataset/uploads.
+# `--resume` skips already-harvested tasks; `--refresh` re-downloads remote harbor sources
+# (no effect on swe-bench, which uses Hugging Face's own dataset cache).
+# Keep bench its own project: dedicated output.traces_dir + publish.repo_id.
+bench:
+  sources: []
+    # - { type: harbor,    source: terminal-bench@2.0 }          # registry spec
+    # - { type: harbor,    source: ./local-tasks }               # local task dir / dir of task dirs
+    # - { type: swe-bench, source: SWE-bench/SWE-bench_Verified, split: test }
+    # - { type: swe-bench, source: SWE-bench/SWE-bench_Lite, instances: [django__django-12345] }
+    #   # optional per-source: repo (git/HF registry), version, instances [..], backend (harbor)
 
 # Number of prompts to run in parallel.
 max_concurrency: 1

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -174,7 +174,9 @@ bench:
     # - { type: harbor,    source: ./local-tasks }               # local task dir / dir of task dirs
     # - { type: swe-bench, source: SWE-bench/SWE-bench_Verified, split: test }
     # - { type: swe-bench, source: SWE-bench/SWE-bench_Lite, instances: [django__django-12345] }
-    #   # optional per-source: repo (git/HF registry), version, instances [..], backend (harbor)
+    # - { type: swe-bench, source: ./my-instances.jsonl, namespace: null }  # build custom images locally
+    #   # optional per-source: repo (git/HF registry), version, instances [..], backend (harbor);
+    #   # swe-bench namespace (default "swebench" pulls published images; null builds locally)
 
 # Number of prompts to run in parallel.
 max_concurrency: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "rich>=13.0",
     "datasets>=2.19.0",
     "huggingface_hub>=0.23.0",
+    "jinja2>=3.1",
     "fastapi>=0.110",
     "uvicorn>=0.29",
     "websockets>=12",
@@ -28,6 +29,10 @@ dependencies = [
 [project.optional-dependencies]
 studio = ["fastapi>=0.110", "uvicorn>=0.29", "websockets>=12"]
 dev = ["pytest>=8.0", "ruff>=0.4", "jinja2>=3.1", "httpx>=0.27"]
+# Per-backend bench extras (install only what you run); `bench` enables both.
+harbor = ["harbor>=0.15.0 ; python_full_version >= '3.12'"]
+swe = ["swebench>=4.1.0", "jinja2>=3.1"]
+bench = ["teich[harbor,swe]"]
 
 [project.scripts]
 teich = "teich.cli:main"

--- a/src/teich/agent_cfg.py
+++ b/src/teich/agent_cfg.py
@@ -1,0 +1,110 @@
+"""Shared, cfg-only agent-configuration helpers.
+
+Prompt mode (``runner.py``) and bench mode (``bench/backends/*``) both need to turn a ``Config``
+into the credentials / model name / base URL an agent CLI consumes. This module is the single
+source of truth for the *pure* parts (no ``self``, no Docker), so bench stops re-deriving a
+thinner, diverging copy (which previously only knew openai/openrouter/anthropic and dropped the
+localhost -> host.docker.internal rewrite).
+
+Note: agent-specific *config files* (codex ``config.toml``, pi ``models.json``/``settings.json``)
+are threaded separately by each backend; this module owns the shared env/model/url derivation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
+
+if TYPE_CHECKING:
+    from .config import Config
+
+# api.provider -> the ENV var its CLI reads for the key. Mirrors runner.ExternalCliRunner
+# (the full map, incl. zai->GLM_API_KEY, deepseek/xai/google/...); unknown providers fall back
+# to ``<PROVIDER>_API_KEY``.
+_PROVIDER_ENV_KEYS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "claude": "ANTHROPIC_API_KEY",
+    "claude_code": "ANTHROPIC_API_KEY",
+    "claude-code": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "nous": "NOUS_API_KEY",
+    "nous_portal": "NOUS_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "xai": "XAI_API_KEY",
+    "grok": "XAI_API_KEY",
+    "zai": "GLM_API_KEY",
+    "z_ai": "GLM_API_KEY",
+    "glm": "GLM_API_KEY",
+}
+
+# api.wire_api values that mean "chat completions" (vs the OpenAI Responses API default).
+CHAT_WIRE_APIS = {"completions", "chat_completions", "chat-completions", "openai-completions"}
+
+
+def provider_env_key(provider: str) -> str:
+    """The ENV var name an agent reads for ``provider``'s API key."""
+    normalized = re.sub(r"[^a-zA-Z0-9_]+", "_", provider.strip().lower())
+    return _PROVIDER_ENV_KEYS.get(normalized, f"{normalized.upper() or 'TEICH'}_API_KEY")
+
+
+def container_base_url(base_url: str | None) -> str | None:
+    """Rewrite a host-local base URL so a container can reach it (localhost -> host.docker.internal)."""
+    if not base_url:
+        return None
+    parsed = urlsplit(base_url)
+    hostname = parsed.hostname or ""
+    if hostname not in {"localhost", "127.0.0.1"}:
+        return base_url
+    netloc = parsed.netloc.replace(hostname, "host.docker.internal", 1)
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+
+
+def pi_prefixed_model(cfg: Config) -> str:
+    """Model for a bench agent; pi picks its provider from a ``<provider>/<model>`` prefix.
+
+    ``model: z-ai/glm-5.2`` + ``api.provider: openrouter`` -> ``openrouter/z-ai/glm-5.2``. Only the
+    pi agent needs the prefix; other agents get the model unchanged.
+    """
+    model = cfg.get_effective_model().strip()
+    if not model:
+        return model
+    provider = (cfg.api.provider or "").strip()
+    if cfg.get_agent_provider() == "pi" and provider and not model.startswith(f"{provider}/"):
+        return f"{provider}/{model}"
+    return model
+
+
+def bench_auth_env(cfg: Config) -> dict[str, str]:
+    """Credential + base-URL env for a bench agent container.
+
+    Sets the provider-specific key from the full provider map (so ``provider: zai`` -> ``GLM_API_KEY``,
+    ``deepseek`` -> ``DEEPSEEK_API_KEY``, ...) plus the OpenAI/OpenRouter/Anthropic compat vars the
+    CLIs actually read, and routes ``base_url`` through :func:`container_base_url` so a host-local
+    endpoint is reachable from inside the container.
+    """
+    env: dict[str, str] = {}
+    provider = cfg.api.provider.strip().lower()
+    api_key = cfg.get_api_key()
+    if api_key:
+        env["TEICH_API_KEY"] = api_key
+        env[provider_env_key(provider)] = api_key  # the correct var for zai/deepseek/xai/...
+        if provider == "anthropic":
+            env["ANTHROPIC_API_KEY"] = api_key
+        else:
+            # codex/claude-code read OPENAI_API_KEY against the configured base_url; pi/hermes on
+            # OpenRouter also read OPENROUTER_API_KEY.
+            env["OPENAI_API_KEY"] = api_key
+            if provider == "openrouter":
+                env["OPENROUTER_API_KEY"] = api_key
+    base_url = container_base_url(cfg.get_base_url())
+    if base_url:
+        env["TEICH_BASE_URL"] = base_url
+        if provider == "anthropic":
+            env["ANTHROPIC_BASE_URL"] = base_url
+        else:
+            env["OPENAI_BASE_URL"] = base_url
+    return env

--- a/src/teich/bench/__init__.py
+++ b/src/teich/bench/__init__.py
@@ -1,0 +1,5 @@
+"""Benchmark (Harbor-format) task generation for ``teich generate --mode bench``."""
+
+from .runner import run_bench
+
+__all__ = ["run_bench"]

--- a/src/teich/bench/backends/__init__.py
+++ b/src/teich/bench/backends/__init__.py
@@ -1,0 +1,50 @@
+"""Bench backends: a registry mapping a source ``type`` to its backend implementation."""
+
+from __future__ import annotations
+
+from .base import (
+    BENCH_SPLITS,
+    BenchBackend,
+    BenchRun,
+    BenchTask,
+    bench_root,
+    bench_stem,
+    existing_output,
+    harvest,
+    primary_score,
+    route_split,
+    source_id,
+)
+from .harbor import HarborBackend
+from .swebench import SweBenchBackend
+
+# type -> backend factory.
+_BACKENDS: dict[str, type] = {
+    HarborBackend.type: HarborBackend,
+    SweBenchBackend.type: SweBenchBackend,
+}
+
+
+def get_backend(source_type: str) -> BenchBackend:
+    """Instantiate the backend for a source ``type``; clear error for an unknown type."""
+    cls = _BACKENDS.get(source_type)
+    if cls is None:
+        supported = ", ".join(sorted(_BACKENDS))
+        raise RuntimeError(f"Unknown bench source type {source_type!r}; supported: {supported}.")
+    return cls()
+
+
+__all__ = [
+    "BENCH_SPLITS",
+    "BenchBackend",
+    "BenchRun",
+    "BenchTask",
+    "bench_root",
+    "bench_stem",
+    "existing_output",
+    "get_backend",
+    "harvest",
+    "primary_score",
+    "route_split",
+    "source_id",
+]

--- a/src/teich/bench/backends/base.py
+++ b/src/teich/bench/backends/base.py
@@ -1,0 +1,202 @@
+"""Pluggable bench-backend abstraction.
+
+A benchmark *source* (declared in ``bench.sources`` with a ``type``) is executed by a
+backend (harbor, swe-bench). Each backend turns a task into a ``BenchRun`` — the agent's
+plain native trace plus a rewards dict — and the *harvest* here (route by score into
+``passed``/``failed``/``borderline`` + a per-task ``metadata/`` sidecar) is backend-agnostic.
+
+Trace/metadata filenames are namespaced by source (``bench-<source>-<task>``) so two sources
+in one dataset can never collide; an unfinished task writes nothing and is retried on resume.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable, Protocol
+
+from ...converter import convert_traces_to_training_data
+
+if TYPE_CHECKING:
+    from ...config import BenchSource, Config
+
+BENCH_SPLITS = ("passed", "failed", "borderline")
+
+
+@dataclass
+class BenchTask:
+    """One unit of work within a source (a harbor task dir, a swe-bench instance, ...)."""
+
+    id: str
+    raw: Any = None
+
+
+@dataclass
+class BenchRun:
+    """A backend's result for one task: the native trace + scores + provenance metadata."""
+
+    native_lines: list[str]
+    rewards: dict[str, float] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class BenchBackend(Protocol):
+    """What a benchmark backend must provide. The driver + harvest are shared."""
+
+    type: str
+
+    def require(self) -> None:
+        """Raise RuntimeError with an install hint if the backend's extra is missing."""
+
+    def tasks(self, cfg: Config, source: BenchSource, *, refresh: bool = False) -> Iterable[BenchTask]:
+        """Resolve a source into its tasks/instances (``refresh`` re-fetches remote data)."""
+
+    def run(self, cfg: Config, source: BenchSource, task: BenchTask) -> BenchRun:
+        """Run the agent on one task in its environment and return its trace + rewards."""
+
+
+def bench_root(cfg: Config) -> Path:
+    """Working dir for backends' intermediates (downloads, sessions, trials).
+
+    A ``bench`` dir beside ``traces_dir`` (parallel to sandbox/failures, outside the
+    dataset); overridable via ``output.bench_dir``. Re-checked here (not just at config
+    load) so a ``--output`` override can't leave ``bench_dir`` inside the dataset.
+    """
+    if cfg.output.bench_dir is not None:
+        root = Path(cfg.output.bench_dir)
+        traces = cfg.output.traces_dir.resolve()
+        if traces == root.resolve() or traces in root.resolve().parents:
+            raise RuntimeError(
+                f"output.bench_dir ({root}) must be outside output.traces_dir "
+                f"({cfg.output.traces_dir}); raw trials/sessions there would be uploaded "
+                "and misclassified as dataset rows."
+            )
+        return root
+    return cfg.output.traces_dir.parent / "bench"
+
+
+def slug(value: str) -> str:
+    """Filesystem-safe slug (``terminal-bench@2.0`` -> ``terminal-bench-2.0``)."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "x"
+
+
+def source_id(source: BenchSource) -> str:
+    """Stable identifier for a source, used to namespace its output files.
+
+    Keyed on the discriminating knobs (not just ``source``): two sources that share a spec
+    but differ in ``repo``/``version``/``split``/``instances``/``backend`` get distinct ids,
+    so they can't overwrite each other's traces or wrongly resume-skip. A suffix is appended
+    only when a field diverges from its default, so the common single-field source keeps a
+    clean, stable id. ``type`` is intentionally excluded (it is recorded in ``metadata`` and
+    the existing namespacing contract is type-independent).
+    """
+    extras = [
+        slug(part)
+        for part in (
+            source.repo,
+            source.version,
+            source.split,
+            (",".join(source.instances) if source.instances else None),
+            source.backend if source.backend != "docker" else None,
+        )
+        if part
+    ]
+    base_id = slug(source.source)
+    return base_id if not extras else f"{base_id}-{slug('-'.join(extras))}"
+
+
+def bench_stem(source: BenchSource, task_id: str) -> str:
+    """Per-task dataset stem, namespaced by source (the co-mingle guard keys on ``bench-``)."""
+    return f"bench-{source_id(source)}-{slug(task_id)}"
+
+
+def existing_output(cfg: Config, stem: str) -> Path | None:
+    """The harvested trace for ``stem`` (in any split), or None — used for ``--resume``."""
+    for split in BENCH_SPLITS:
+        path = cfg.output.traces_dir / split / f"{stem}.jsonl"
+        if path.is_file() and path.stat().st_size > 0:
+            return path
+    return None
+
+
+def numeric(value: Any) -> float | None:
+    """A real number (bools excluded) as float, else None."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def rewards_from_mapping(data: Any) -> dict[str, float] | None:
+    """The full dict of numeric scores (no clamping). Accepts ``{"rewards": {...}}`` or flat."""
+    if not isinstance(data, dict):
+        return None
+    rewards = data.get("rewards") if isinstance(data.get("rewards"), dict) else data
+    scores = {key: numeric(val) for key, val in rewards.items() if numeric(val) is not None}
+    return scores or None
+
+
+def primary_score(rewards: dict[str, float] | None) -> float | None:
+    """The scalar used for routing: the ``reward`` key, else the first numeric value."""
+    if not rewards:
+        return None
+    primary = numeric(rewards.get("reward"))
+    if primary is not None:
+        return primary
+    for value in rewards.values():
+        primary = numeric(value)
+        if primary is not None:
+            return primary
+    return None
+
+
+def route_split(primary: float | None) -> str:
+    """passed = score 1, failed = score 0 / unscored, borderline = any other value."""
+    if primary is None or primary == 0:
+        return "failed"
+    if primary == 1:
+        return "passed"
+    return "borderline"
+
+
+def trace_metadata(native_dir: Path | None) -> dict[str, Any]:
+    """Metadata teich's converter recovers from a native trace (model, session, cwd, ...)."""
+    if native_dir is None:
+        return {}
+    try:
+        rows = convert_traces_to_training_data(native_dir)
+    except Exception:  # metadata is best-effort; never fail the harvest over it
+        return {}
+    return rows[0].get("metadata", {}) if rows else {}
+
+
+def harvest(cfg: Config, source: BenchSource, task: BenchTask, run: BenchRun) -> tuple[list[Path], str]:
+    """Write a backend's native trace (routed by score) + a per-task metadata sidecar.
+
+    Returns (written paths, split). The trace is written verbatim (plain agent-trace data);
+    scores + provenance go to ``output/metadata/<stem>.json``.
+    """
+    primary = primary_score(run.rewards)
+    split = route_split(primary)
+    stem = bench_stem(source, task.id)
+
+    trace_path = cfg.output.traces_dir / split / f"{stem}.jsonl"
+    trace_path.parent.mkdir(parents=True, exist_ok=True)
+    trace_path.write_text("\n".join(run.native_lines) + "\n", encoding="utf-8")
+
+    metadata: dict[str, Any] = {
+        "task": task.id,
+        "source": source_id(source),
+        "type": source.type,
+        "split": split,
+        "reward": primary,
+        "rewards": run.rewards or {},
+        "agent": cfg.get_agent_provider(),
+        "trace_file": f"{split}/{stem}.jsonl",
+        **run.metadata,
+    }
+    meta_path = cfg.output.traces_dir / "metadata" / f"{stem}.json"
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+    return [trace_path], split

--- a/src/teich/bench/backends/base.py
+++ b/src/teich/bench/backends/base.py
@@ -11,6 +11,7 @@ in one dataset can never collide; an unfinished task writes nothing and is retri
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from dataclasses import dataclass, field
@@ -82,6 +83,23 @@ def slug(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "x"
 
 
+def _instances_key(instances: list[str] | None) -> str | None:
+    """A bounded, order-independent discriminator for an ``instances`` subset.
+
+    The full comma-joined list would otherwise flow through ``source_id`` into per-task
+    filenames, Docker tags, and container/env-file names; a dozen ~22-char SWE-bench IDs
+    blow past the 255-byte path-component and 128-char Docker-tag limits and crash the run
+    before any result is written. Short lists stay readable; longer ones collapse to a
+    stable hash (sorted, so listing order doesn't spawn a distinct id).
+    """
+    if not instances:
+        return None
+    joined = ",".join(sorted(instances))
+    if len(joined) <= 40:
+        return joined
+    return "i" + hashlib.sha1(joined.encode("utf-8")).hexdigest()[:8]
+
+
 def source_id(source: BenchSource) -> str:
     """Stable identifier for a source, used to namespace its output files.
 
@@ -98,7 +116,7 @@ def source_id(source: BenchSource) -> str:
             source.repo,
             source.version,
             source.split,
-            (",".join(source.instances) if source.instances else None),
+            _instances_key(source.instances),
             source.backend if source.backend != "docker" else None,
         )
         if part

--- a/src/teich/bench/backends/base.py
+++ b/src/teich/bench/backends/base.py
@@ -65,17 +65,18 @@ def bench_root(cfg: Config) -> Path:
     dataset); overridable via ``output.bench_dir``. Re-checked here (not just at config
     load) so a ``--output`` override can't leave ``bench_dir`` inside the dataset.
     """
-    if cfg.output.bench_dir is not None:
-        root = Path(cfg.output.bench_dir)
-        traces = cfg.output.traces_dir.resolve()
-        if traces == root.resolve() or traces in root.resolve().parents:
-            raise RuntimeError(
-                f"output.bench_dir ({root}) must be outside output.traces_dir "
-                f"({cfg.output.traces_dir}); raw trials/sessions there would be uploaded "
-                "and misclassified as dataset rows."
-            )
-        return root
-    return cfg.output.traces_dir.parent / "bench"
+    root = Path(cfg.output.bench_dir) if cfg.output.bench_dir is not None else cfg.output.traces_dir.parent / "bench"
+    # Guard both the explicit override and the computed default: a bench root at/under traces_dir
+    # (e.g. output.traces_dir named ``bench``, so the sibling default collides with it) would get
+    # raw trials/sessions uploaded and misclassified as dataset rows.
+    traces = cfg.output.traces_dir.resolve()
+    if traces == root.resolve() or traces in root.resolve().parents:
+        raise RuntimeError(
+            f"bench working dir ({root}) must be outside output.traces_dir "
+            f"({cfg.output.traces_dir}); raw trials/sessions there would be uploaded and "
+            "misclassified as dataset rows. Set output.bench_dir explicitly or rename traces_dir."
+        )
+    return root
 
 
 def slug(value: str) -> str:
@@ -200,6 +201,12 @@ def harvest(cfg: Config, source: BenchSource, task: BenchTask, run: BenchRun) ->
     stem = bench_stem(source, task.id)
 
     trace_path = cfg.output.traces_dir / split / f"{stem}.jsonl"
+    # A re-run (without --resume) whose score crosses a routing boundary would otherwise leave a
+    # stale copy in the old split; the dataset scanners read every split, so a task would appear
+    # twice with contradictory labels. Drop any sibling copy before writing the new one.
+    for other in BENCH_SPLITS:
+        if other != split:
+            (cfg.output.traces_dir / other / f"{stem}.jsonl").unlink(missing_ok=True)
     trace_path.parent.mkdir(parents=True, exist_ok=True)
     trace_path.write_text("\n".join(run.native_lines) + "\n", encoding="utf-8")
 

--- a/src/teich/bench/backends/harbor.py
+++ b/src/teich/bench/backends/harbor.py
@@ -19,6 +19,7 @@ from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ... import agent_cfg
 from . import base
 
 if TYPE_CHECKING:
@@ -51,42 +52,16 @@ def _agent_name_for(provider: str) -> str:
 
 
 def _agent_auth_env(cfg: Config) -> dict[str, str]:
-    """Model credentials for the in-container agent from teich's `api` config.
-
-    An ``anthropic`` project exports the key as ``ANTHROPIC_API_KEY`` only (claude-code reads
-    it; it must not be shadowed under ``OPENAI_API_KEY``). Otherwise the key goes to
-    ``OPENAI_API_KEY``, plus ``OPENROUTER_API_KEY`` for an OpenRouter project (pi/hermes read
-    that name while codex/claude-code use ``OPENAI_API_KEY`` against the OpenRouter base_url).
-    """
-    env: dict[str, str] = {}
-    api_key = cfg.get_api_key()
-    if api_key:
-        if cfg.api.provider == "anthropic":
-            env["ANTHROPIC_API_KEY"] = api_key
-        else:
-            env["OPENAI_API_KEY"] = api_key
-            if cfg.api.provider == "openrouter":
-                env["OPENROUTER_API_KEY"] = api_key
-    base_url = cfg.get_base_url()
-    if base_url:
-        env["OPENAI_BASE_URL"] = base_url
-    return env
+    """Model credentials + base URL for the in-container agent — shared ``agent_cfg`` derivation
+    (the same one prompt mode uses), so every provider gets the right key var (not just
+    openai/openrouter/anthropic) and a host-local base_url reaches the container."""
+    return agent_cfg.bench_auth_env(cfg)
 
 
-def _bench_model_name(cfg: Config) -> str | None:
-    """Model name for the in-container agent, with harbor's provider prefix when needed.
-
-    harbor's pi agent requires ``<provider>/<model>`` and splits on the first ``/`` to pick
-    the credential env var, so ``model: z-ai/glm-5.2`` + ``api.provider: openrouter`` is
-    prefixed to ``openrouter/z-ai/glm-5.2`` (else it reads provider ``z-ai`` and finds no key).
-    """
-    model = cfg.get_effective_model()
-    if not model:
-        return model
-    api_provider = (cfg.api.provider or "").strip()
-    if cfg.get_agent_provider() == "pi" and api_provider and not model.startswith(f"{api_provider}/"):
-        return f"{api_provider}/{model}"
-    return model
+def _bench_model_name(cfg: Config) -> str:
+    """Model name for the in-container agent; pi requires a ``<provider>/<model>`` prefix so it
+    splits on the first ``/`` to pick the credential env var (shared ``agent_cfg`` helper)."""
+    return agent_cfg.pi_prefixed_model(cfg)
 
 
 def _resolve_task_dirs(root: str | Path) -> list[Path]:

--- a/src/teich/bench/backends/harbor.py
+++ b/src/teich/bench/backends/harbor.py
@@ -1,0 +1,410 @@
+"""Harbor bench backend.
+
+Drives the optional ``harbor`` package over Harbor-format tasks: resolve a source
+(local dir, registry spec, or git/HF registry) into task dirs, run each in its own
+environment image via harbor's built-in agent, and return the native trace + the task
+verifier's reward dict. harbor is imported lazily (the ``teich[harbor]`` extra, py>=3.12).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from . import base
+
+if TYPE_CHECKING:
+    from ...config import BenchSource, Config
+
+HARBOR_INSTALL_HINT = (
+    "The harbor bench backend needs the optional 'harbor' extra: install with "
+    "`pip install 'teich[harbor]'` (requires Python 3.12+)."
+)
+
+# teich agent provider -> harbor AgentName value.
+_PROVIDER_TO_AGENT: dict[str, str] = {
+    "codex": "codex",
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "claude_code": "claude-code",
+    "pi": "pi",
+    "hermes": "hermes",
+}
+
+
+def _agent_name_for(provider: str) -> str:
+    name = _PROVIDER_TO_AGENT.get(provider.strip().lower())
+    if not name:
+        raise RuntimeError(
+            f"Bench mode does not support agent provider {provider!r}; "
+            "use one of: codex, claude-code, pi, hermes."
+        )
+    return name
+
+
+def _agent_auth_env(cfg: Config) -> dict[str, str]:
+    """Model credentials for the in-container agent from teich's `api` config.
+
+    An ``anthropic`` project exports the key as ``ANTHROPIC_API_KEY`` only (claude-code reads
+    it; it must not be shadowed under ``OPENAI_API_KEY``). Otherwise the key goes to
+    ``OPENAI_API_KEY``, plus ``OPENROUTER_API_KEY`` for an OpenRouter project (pi/hermes read
+    that name while codex/claude-code use ``OPENAI_API_KEY`` against the OpenRouter base_url).
+    """
+    env: dict[str, str] = {}
+    api_key = cfg.get_api_key()
+    if api_key:
+        if cfg.api.provider == "anthropic":
+            env["ANTHROPIC_API_KEY"] = api_key
+        else:
+            env["OPENAI_API_KEY"] = api_key
+            if cfg.api.provider == "openrouter":
+                env["OPENROUTER_API_KEY"] = api_key
+    base_url = cfg.get_base_url()
+    if base_url:
+        env["OPENAI_BASE_URL"] = base_url
+    return env
+
+
+def _bench_model_name(cfg: Config) -> str | None:
+    """Model name for the in-container agent, with harbor's provider prefix when needed.
+
+    harbor's pi agent requires ``<provider>/<model>`` and splits on the first ``/`` to pick
+    the credential env var, so ``model: z-ai/glm-5.2`` + ``api.provider: openrouter`` is
+    prefixed to ``openrouter/z-ai/glm-5.2`` (else it reads provider ``z-ai`` and finds no key).
+    """
+    model = cfg.get_effective_model()
+    if not model:
+        return model
+    api_provider = (cfg.api.provider or "").strip()
+    if cfg.get_agent_provider() == "pi" and api_provider and not model.startswith(f"{api_provider}/"):
+        return f"{api_provider}/{model}"
+    return model
+
+
+def _resolve_task_dirs(root: str | Path) -> list[Path]:
+    """Resolve a local Harbor task root to one or more task dirs (single-task or dir-of-tasks)."""
+    path = Path(root).expanduser()
+    if not path.exists():
+        raise RuntimeError(f"bench task directory not found: {path}.")
+    if (path / "task.toml").is_file():
+        return [path]
+    tasks = sorted(d for d in path.iterdir() if d.is_dir() and (d / "task.toml").is_file())
+    if not tasks:
+        raise RuntimeError(f"No Harbor tasks (a task.toml) found under {path}.")
+    return tasks
+
+
+def _classify_remote_source(source: str, repo: str | None, version: str | None) -> tuple[str, str]:
+    """Map a remote source to (client kind, harbor dataset ref), mirroring ``harbor download``."""
+    has_version = "@" in source
+    name = source.split("@", 1)[0]
+
+    def _ref(default_version: str | None = None) -> str:
+        if has_version:
+            return source
+        if version:
+            return f"{source}@{version}"
+        return f"{source}@{default_version}" if default_version else source
+
+    if repo:
+        return "repo", _ref()
+    if "/" in name:
+        return "package", _ref(default_version="latest")
+    return "registry", _ref()
+
+
+def _source_slug(source: str, version: str | None) -> str:
+    raw = source if "@" in source else (f"{source}@{version}" if version else source)
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("-") or "source"
+
+
+def _task_root(cache_dir: Path) -> Path | None:
+    """The common parent of every exported ``task.toml`` (harbor exports ``<ds>/<task>/``)."""
+    parents = sorted({toml.parent for toml in cache_dir.rglob("task.toml")})
+    if not parents:
+        return None
+    if len(parents) == 1:
+        return parents[0]
+    return Path(os.path.commonpath([str(p) for p in parents]))
+
+
+async def _download_async(source: BenchSource, cache_dir: Path) -> None:
+    kind, ref = _classify_remote_source(source.source.strip(), source.repo, source.version)
+    if kind == "repo":
+        from harbor.registry.client.factory import RegistryClientFactory
+
+        client = RegistryClientFactory.create(repo=source.repo)
+    elif kind == "package":
+        from harbor.registry.client.package import PackageDatasetClient
+
+        client = PackageDatasetClient()
+    else:
+        from harbor.registry.client.factory import RegistryClientFactory
+
+        client = RegistryClientFactory.create()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    await client.download_dataset(ref, overwrite=True, output_dir=cache_dir, export=True)
+
+
+def _fetch_remote(source: BenchSource, cache_dir: Path) -> None:
+    try:
+        asyncio.run(_download_async(source, cache_dir))
+    except Exception as exc:  # network / unknown dataset / auth -> a clean bench error
+        raise RuntimeError(
+            f"Failed to download bench source {source.source!r}: {type(exc).__name__}: {exc}. "
+            "Check the spec/version, network, and (for HF/private registries) HF_TOKEN."
+        ) from exc
+
+
+def _resolve_source(cfg: Config, source: BenchSource, *, refresh: bool) -> Path:
+    """Return a local task root: a local path as-is, else download the remote spec."""
+    spec = source.source.strip()
+    local = Path(spec).expanduser()
+    if local.exists():
+        return local
+    cache_dir = base.bench_root(cfg) / "sources" / _source_slug(spec, source.version)
+    root = None if refresh else _task_root(cache_dir)
+    if root is None:
+        if refresh and cache_dir.exists():
+            shutil.rmtree(cache_dir, ignore_errors=True)
+        _fetch_remote(source, cache_dir)
+        root = _task_root(cache_dir)
+    if root is None:
+        raise RuntimeError(f"bench source {spec!r}: no Harbor tasks found after download into {cache_dir}.")
+    return root
+
+
+def _build_trial_config(cfg: Config, source: BenchSource, task_dir: Path, trials_dir: Path) -> Any:
+    from harbor.models.agent.name import AgentName
+    from harbor.models.environment_type import EnvironmentType
+    from harbor.models.trial.config import TaskConfig, TrialConfig
+
+    config = TrialConfig(task=TaskConfig(path=task_dir), trials_dir=trials_dir)
+    config.agent.name = AgentName(_agent_name_for(cfg.get_agent_provider()))
+    model = _bench_model_name(cfg)
+    if model:
+        config.agent.model_name = model
+    config.agent.env.update(_agent_auth_env(cfg))
+    try:
+        config.environment.type = EnvironmentType(source.backend)
+    except ValueError as exc:
+        supported = ", ".join(t.value for t in EnvironmentType)
+        raise RuntimeError(
+            f"Unknown backend {source.backend!r}; harbor supports: {supported}."
+        ) from exc
+    return config
+
+
+async def _create_and_run(config: Any) -> tuple[Any, Any]:
+    from harbor.trial.trial import Trial
+
+    trial = await Trial.create(config)
+    result = await trial.run()
+    return trial, result
+
+
+def _agent_dir(trial: Any) -> Path | None:
+    paths = getattr(trial, "paths", None)
+    agent_dir = getattr(paths, "agent_dir", None)
+    return Path(agent_dir) if agent_dir else None
+
+
+def _pi_stream_to_session_events(pi_txt: Path) -> list[dict[str, Any]]:
+    """Normalize pi's ``--mode json`` stream into pi session events.
+
+    harbor runs pi with ``--no-session`` (only a streaming log + a leading non-JSON
+    ``Warning:`` line). Keep the ``session`` header, turn each ``message_end`` into a
+    ``message``, and synthesize a ``model_change`` from the first assistant message.
+    """
+    events: list[dict[str, Any]] = []
+    model_change_added = False
+    for raw in pi_txt.read_text(encoding="utf-8").splitlines():
+        raw = raw.strip()
+        if not raw.startswith("{"):
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type == "session":
+            events.append(event)
+        elif event_type == "message_end":
+            message = event.get("message")
+            if not isinstance(message, dict) or not message.get("role"):
+                continue
+            if not model_change_added and message.get("role") == "assistant":
+                provider, model_id = message.get("provider"), message.get("model")
+                if isinstance(provider, str) and isinstance(model_id, str):
+                    events.append({"type": "model_change", "provider": provider, "modelId": model_id})
+                    model_change_added = True
+            events.append({"type": "message", "message": message})
+    return events
+
+
+def _native_trace(
+    cfg: Config, source: BenchSource, agent_dir: Path, task_id: str
+) -> tuple[list[str], Path | None]:
+    """The agent's plain native trace as JSONL lines + an isolated dir (for metadata recovery)."""
+    sessions = agent_dir / "sessions"  # codex / claude-code export a native session dir
+    if sessions.is_dir() and any(sessions.glob("*.jsonl")):
+        lines = [
+            line
+            for path in sorted(sessions.glob("*.jsonl"))
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        return lines, sessions
+    pi_txt = agent_dir / "pi.txt"  # pi runs --no-session: normalize its --mode json stream
+    if pi_txt.is_file():
+        events = _pi_stream_to_session_events(pi_txt)
+        if events:
+            # Namespace by source so concurrent same-named tasks from different sources can't race.
+            norm_dir = base.bench_root(cfg) / "sessions" / base.bench_stem(source, task_id)
+            norm_dir.mkdir(parents=True, exist_ok=True)
+            lines = [json.dumps(event, ensure_ascii=False) for event in events]
+            (norm_dir / "pi.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+            return lines, norm_dir
+    jsonls = sorted(agent_dir.rglob("*.jsonl"))  # last resort: anything the agent left
+    if jsonls:
+        lines = [
+            line
+            for path in jsonls
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        return lines, agent_dir
+    return [], None
+
+
+def _rewards_from_result(result: Any) -> dict[str, float] | None:
+    verifier = getattr(result, "verifier_result", None)
+    if isinstance(verifier, dict):
+        return base.rewards_from_mapping(verifier)
+    return base.rewards_from_mapping(getattr(verifier, "rewards", None))
+
+
+def _rewards_from_files(base_dir: Path | None) -> dict[str, float] | None:
+    if base_dir is None:
+        return None
+    for name in ("rewards.json", "reward.json"):
+        for path in sorted(base_dir.rglob(name)):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            scores = base.rewards_from_mapping(data)
+            if scores is not None:
+                return scores
+    for path in sorted(base_dir.rglob("reward.txt")):
+        try:
+            value = base.numeric(float(path.read_text(encoding="utf-8").strip()))
+        except (OSError, ValueError):
+            continue
+        if value is not None:
+            return {"reward": value}
+    return None
+
+
+def _sanitize_hb_image(name: str) -> str:
+    """Replicate harbor's docker image-name sanitizer (environments/docker/docker.py)."""
+    name = name.lower()
+    if not re.match(r"^[a-z0-9]", name):
+        name = "0" + name
+    return re.sub(r"[^a-z0-9._-]", "-", name)
+
+
+def _harbor_image_names(trial: Any, task_id: str) -> list[str]:
+    """Per-task image name(s) harbor built. harbor's teardown runs ``compose down --rmi local``,
+    which leaves the custom-tagged ``hb__<task>`` image behind, so we remove it ourselves.
+
+    Prefers the actual name off the trial's environments; always includes the deterministic
+    ``sanitize("hb__" + short_name)`` (short_name == the task dir name == task_id), which also
+    covers the error path where the trial object was never returned.
+    """
+    names: set[str] = set()
+    for attr in ("agent_environment", "verifier_environment"):
+        env = getattr(trial, attr, None) if trial is not None else None
+        try:
+            value = getattr(env, "_main_image_name", None)
+        except Exception:
+            value = None
+        if isinstance(value, str) and value:
+            names.add(value)
+    short = getattr(getattr(trial, "task", None), "short_name", None) if trial is not None else None
+    names.add(_sanitize_hb_image(f"hb__{short or task_id}"))
+    return sorted(names)
+
+
+def _purge_images(names: list[str]) -> None:
+    """Best-effort ``docker rmi -f`` of the given images (ignore not-found / in-use / no docker)."""
+    for name in names:
+        try:
+            # Short timeout: this also runs in the finally after a Ctrl-C, so a slow/unhappy
+            # docker must not stall the exit for 2 minutes per image.
+            subprocess.run(["docker", "rmi", "-f", name], capture_output=True, timeout=30)
+        except Exception:
+            pass
+
+
+class HarborBackend:
+    """Runs Harbor-format tasks via the harbor package (one container per task)."""
+
+    type = "harbor"
+
+    def require(self) -> None:
+        if sys.version_info < (3, 12):
+            raise RuntimeError(
+                "The harbor bench backend requires Python 3.12+ "
+                f"(current: {sys.version_info.major}.{sys.version_info.minor}). {HARBOR_INSTALL_HINT}"
+            )
+        try:
+            import harbor  # noqa: F401
+        except ImportError as exc:  # pragma: no cover - only without the extra
+            raise RuntimeError(HARBOR_INSTALL_HINT) from exc
+
+    def tasks(self, cfg: Config, source: BenchSource, *, refresh: bool = False) -> list[base.BenchTask]:
+        root = _resolve_source(cfg, source, refresh=refresh)
+        return [base.BenchTask(id=task_dir.name, raw=task_dir) for task_dir in _resolve_task_dirs(root)]
+
+    def run(self, cfg: Config, source: BenchSource, task: base.BenchTask) -> base.BenchRun:
+        trials_dir = base.bench_root(cfg) / "trials"
+        trials_dir.mkdir(parents=True, exist_ok=True)
+        config = _build_trial_config(cfg, source, task.raw, trials_dir)
+        trial: Any = None
+        try:
+            trial, result = asyncio.run(_create_and_run(config))
+
+            exc_info = getattr(result, "exception_info", None)
+            exception: str | None = None
+            if exc_info:
+                exception = (
+                    exc_info.get("exception_type") if isinstance(exc_info, dict)
+                    else getattr(exc_info, "exception_type", None)
+                ) or "agent error"
+
+            agent_dir = _agent_dir(trial)
+            lines: list[str] = []
+            native_dir: Path | None = None
+            if agent_dir is not None and agent_dir.exists():
+                lines, native_dir = _native_trace(cfg, source, agent_dir, task.id)
+
+            rewards = _rewards_from_result(result) or _rewards_from_files(
+                agent_dir.parent if agent_dir else None
+            )
+            metadata = {"exception": exception, **base.trace_metadata(native_dir)}
+            return base.BenchRun(native_lines=lines, rewards=rewards, metadata=metadata)
+        finally:
+            # harbor's `down --rmi local` leaves the `hb__<task>` image; remove it on every
+            # outcome (passed/failed/error) so per-task images don't pile up and fill the disk.
+            if not cfg.output.keep_bench_images:
+                _purge_images(_harbor_image_names(trial, task.id))

--- a/src/teich/bench/backends/harbor.py
+++ b/src/teich/bench/backends/harbor.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -328,13 +329,41 @@ def _sanitize_hb_image(name: str) -> str:
     return re.sub(r"[^a-z0-9._-]", "-", name)
 
 
-def _harbor_image_names(trial: Any, task_id: str) -> list[str]:
-    """Per-task image name(s) harbor built. harbor's teardown runs ``compose down --rmi local``,
-    which leaves the custom-tagged ``hb__<task>`` image behind, so we remove it ourselves.
+def _task_prebuilt_images(task_dir: Path | None) -> list[str]:
+    """The task's prebuilt image name(s) from task.toml: ``[environment].docker_image``
+    plus a separate ``[verifier.environment].docker_image`` when declared.
+
+    A task that declares one runs in harbor's prebuilt mode: compose pulls that image and
+    runs it directly — no ``hb__<task>`` image is ever built — and harbor's teardown
+    (``down --rmi local``) never removes a pulled tagged image. All terminal-bench 2.0
+    tasks are prebuilt, so without these names the purge is a no-op and each task leaks
+    its (often multi-GB) image.
+    """
+    if task_dir is None:
+        return []
+    try:
+        import tomllib  # py3.11+; the harbor backend already requires 3.12
+
+        with (Path(task_dir) / "task.toml").open("rb") as fh:
+            data = tomllib.load(fh)
+        candidates = [
+            data.get("environment", {}).get("docker_image"),
+            data.get("verifier", {}).get("environment", {}).get("docker_image"),
+        ]
+    except Exception:  # missing/unparseable task.toml — stay best-effort like the purge itself
+        return []
+    return [image for image in candidates if isinstance(image, str) and image.strip()]
+
+
+def _harbor_image_names(trial: Any, task_id: str, task_dir: Path | None = None) -> list[str]:
+    """Per-task image name(s) harbor leaves behind after ``compose down --rmi local``:
+    the custom-tagged ``hb__<task>`` image (built mode) and/or the pulled prebuilt
+    image(s) declared in task.toml, so we remove them ourselves.
 
     Prefers the actual name off the trial's environments; always includes the deterministic
-    ``sanitize("hb__" + short_name)`` (short_name == the task dir name == task_id), which also
-    covers the error path where the trial object was never returned.
+    ``sanitize("hb__" + short_name)`` (short_name == the task dir name == task_id) and the
+    task.toml prebuilt names, which also cover the error/interrupt path where the trial
+    object was never returned.
     """
     names: set[str] = set()
     for attr in ("agent_environment", "verifier_environment"):
@@ -347,6 +376,7 @@ def _harbor_image_names(trial: Any, task_id: str) -> list[str]:
             names.add(value)
     short = getattr(getattr(trial, "task", None), "short_name", None) if trial is not None else None
     names.add(_sanitize_hb_image(f"hb__{short or task_id}"))
+    names.update(_task_prebuilt_images(task_dir))
     return sorted(names)
 
 
@@ -366,6 +396,13 @@ class HarborBackend:
 
     type = "harbor"
 
+    def __init__(self) -> None:
+        # Prebuilt images declared by more than one task of this source (see tasks()).
+        # rmi'ing a shared image after one task can race a concurrent sibling's
+        # `compose up` (No such image -> that task fails) and forces a re-pull per task,
+        # so those are kept; only images unique to a task are purged after it.
+        self._shared_prebuilt: frozenset[str] = frozenset()
+
     def require(self) -> None:
         if sys.version_info < (3, 12):
             raise RuntimeError(
@@ -379,7 +416,12 @@ class HarborBackend:
 
     def tasks(self, cfg: Config, source: BenchSource, *, refresh: bool = False) -> list[base.BenchTask]:
         root = _resolve_source(cfg, source, refresh=refresh)
-        return [base.BenchTask(id=task_dir.name, raw=task_dir) for task_dir in _resolve_task_dirs(root)]
+        task_dirs = _resolve_task_dirs(root)
+        # Computed once, before any run() is dispatched (runner threads only call run()).
+        # Deduped per task: one task using the same image for agent + verifier isn't sharing.
+        counts = Counter(image for task_dir in task_dirs for image in set(_task_prebuilt_images(task_dir)))
+        self._shared_prebuilt = frozenset(image for image, n in counts.items() if n > 1)
+        return [base.BenchTask(id=task_dir.name, raw=task_dir) for task_dir in task_dirs]
 
     def run(self, cfg: Config, source: BenchSource, task: base.BenchTask) -> base.BenchRun:
         trials_dir = base.bench_root(cfg) / "trials"
@@ -409,7 +451,10 @@ class HarborBackend:
             metadata = {"exception": exception, **base.trace_metadata(native_dir)}
             return base.BenchRun(native_lines=lines, rewards=rewards, metadata=metadata)
         finally:
-            # harbor's `down --rmi local` leaves the `hb__<task>` image; remove it on every
-            # outcome (passed/failed/error) so per-task images don't pile up and fill the disk.
+            # harbor's `down --rmi local` leaves the `hb__<task>` image (built mode) and the
+            # pulled task image(s) (prebuilt mode); remove them on every outcome
+            # (passed/failed/error/Ctrl-C) so per-task images don't pile up and fill the
+            # disk. Images shared with sibling tasks are kept (see __init__).
             if not cfg.output.keep_bench_images:
-                _purge_images(_harbor_image_names(trial, task.id))
+                names = _harbor_image_names(trial, task.id, task.raw)
+                _purge_images([name for name in names if name not in self._shared_prebuilt])

--- a/src/teich/bench/backends/harbor.py
+++ b/src/teich/bench/backends/harbor.py
@@ -120,8 +120,13 @@ def _classify_remote_source(source: str, repo: str | None, version: str | None) 
     return "registry", _ref()
 
 
-def _source_slug(source: str, version: str | None) -> str:
+def _source_slug(source: str, version: str | None, repo: str | None = None) -> str:
     raw = source if "@" in source else (f"{source}@{version}" if version else source)
+    # ``repo`` selects the download origin in ``_download_async`` and is a discriminating
+    # knob in ``source_id``; fold it into the cache key too, else two sources with the same
+    # spec/version but different repos share a cache dir and the second reuses the first's tasks.
+    if repo:
+        raw = f"{repo}#{raw}"
     return re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("-") or "source"
 
 
@@ -169,7 +174,7 @@ def _resolve_source(cfg: Config, source: BenchSource, *, refresh: bool) -> Path:
     local = Path(spec).expanduser()
     if local.exists():
         return local
-    cache_dir = base.bench_root(cfg) / "sources" / _source_slug(spec, source.version)
+    cache_dir = base.bench_root(cfg) / "sources" / _source_slug(spec, source.version, source.repo)
     root = None if refresh else _task_root(cache_dir)
     if root is None:
         if refresh and cache_dir.exists():

--- a/src/teich/bench/backends/swebench.py
+++ b/src/teich/bench/backends/swebench.py
@@ -335,7 +335,11 @@ def _run_agent(
     run = _run_command(cfg, layer)
     shell = (
         f"cd {TESTBED} && ({run} || true) && git -C {TESTBED} add -A && "
-        f"git -C {TESTBED} diff --cached --no-color > {capture} 2>/dev/null || true"
+        f"git -C {TESTBED} diff --cached --no-color > {capture} 2>/dev/null || true; "
+        # The container runs as root and writes the agent's session dir into the bind-mounted
+        # capture tree. On native-Linux Docker those files land root-owned, so the next no-resume
+        # run's shutil.rmtree(capture_dir) fails; hand the tree back to the host UID before exit.
+        f"chmod -R a+rwX {CAPTURE} 2>/dev/null || true"
     )
     cmd = [
         "docker", "run", "--rm", "--name", container, "--env-file", str(env_file),

--- a/src/teich/bench/backends/swebench.py
+++ b/src/teich/bench/backends/swebench.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ... import agent_cfg
 from . import base
 
 if TYPE_CHECKING:
@@ -136,19 +137,8 @@ def _agent_layer(cfg: Config) -> AgentLayer:
 
 
 def _model_name(cfg: Config) -> str:
-    """Model for the in-container agent, with the pi ``<provider>/<model>`` prefix when needed.
-
-    Mirrors the harbor backend's prefix rule: pi splits ``<provider>/<model>`` to pick the
-    credential env var, so ``model: z-ai/glm-5.2`` + ``api.provider: openrouter`` becomes
-    ``openrouter/z-ai/glm-5.2``.
-    """
-    model = cfg.get_effective_model().strip()
-    if not model:
-        return model
-    api_provider = (cfg.api.provider or "").strip()
-    if cfg.get_agent_provider() == "pi" and api_provider and not model.startswith(f"{api_provider}/"):
-        return f"{api_provider}/{model}"
-    return model
+    """Model for the in-container agent (pi gets a ``<provider>/<model>`` prefix). Shared helper."""
+    return agent_cfg.pi_prefixed_model(cfg)
 
 
 def _run_command(cfg: Config, layer: AgentLayer) -> str:
@@ -160,25 +150,11 @@ def _run_command(cfg: Config, layer: AgentLayer) -> str:
 
 
 def _auth_env(cfg: Config) -> dict[str, str]:
-    """Model credentials for the in-container agent, mirroring the harbor backend.
-
-    An ``anthropic`` project sets ``ANTHROPIC_API_KEY`` only (not shadowed under
-    ``OPENAI_API_KEY``); otherwise the key goes to ``OPENAI_API_KEY`` plus
-    ``OPENROUTER_API_KEY`` for an OpenRouter project.
-    """
-    env: dict[str, str] = {}
-    api_key = cfg.get_api_key()
-    if api_key:
-        if cfg.api.provider == "anthropic":
-            env["ANTHROPIC_API_KEY"] = api_key
-        else:
-            env["OPENAI_API_KEY"] = api_key
-            if cfg.api.provider == "openrouter":
-                env["OPENROUTER_API_KEY"] = api_key
-    base_url = cfg.get_base_url()
-    if base_url:
-        env["OPENAI_BASE_URL"] = base_url
-    return env
+    """Model credentials + base URL for the in-container agent — the same derivation prompt mode
+    uses (shared ``agent_cfg``), so every provider (zai/deepseek/xai/... not just
+    openai/openrouter/anthropic) gets the right key var and a host-local base_url is rewritten
+    to host.docker.internal."""
+    return agent_cfg.bench_auth_env(cfg)
 
 
 def render_agent_dockerfile(

--- a/src/teich/bench/backends/swebench.py
+++ b/src/teich/bench/backends/swebench.py
@@ -1,0 +1,452 @@
+"""SWE-bench bench backend.
+
+SWE-bench ships an *evaluation* harness (it grades a patch against held-out tests); it
+does not run agents. So teich supplies the agent: load instances from a SWE-bench dataset,
+run teich's agent against the clean repo @ base_commit inside swebench's prebuilt instance
+image (with a thin Jinja-rendered agent layer on top), take the agent's ``git diff`` as the
+candidate patch, and hand that to swebench's ``run_instance`` for grading. The ``resolved``
+verdict becomes the reward. swebench is imported lazily (the ``teich[swe]`` extra, py>=3.10).
+
+Two seams here are inherently Docker-bound and validated by an integration run rather than
+unit tests: building the agent image (``_build_image``) + running the agent (``_run_agent``),
+and grading (``_grade``). Everything else — dataset loading, the Dockerfile render, and the
+reward mapping — is plain logic with unit coverage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from . import base
+
+if TYPE_CHECKING:
+    from ...config import BenchSource, Config
+
+SWE_INSTALL_HINT = (
+    "The swe-bench bench backend needs the optional 'swe' extra: install with "
+    "`pip install 'teich[swe]'` (requires Python 3.10+)."
+)
+
+# SWE-bench publishes prebuilt instance images under this Docker namespace; using them
+# means we pull one image and add a thin agent layer instead of rebuilding base+env+instance.
+DEFAULT_NAMESPACE = "swebench"
+TESTBED = "/testbed"  # swebench DOCKER_WORKDIR: the repo @ base_commit lives here
+CAPTURE = "/teich-out"  # mounted host dir for the prompt, the agent session, and the diff
+
+_TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
+
+
+# --------------------------------------------------------------------------- agent layer
+
+# Installs Node.js (for the JS agent CLIs) onto a swebench instance image (Debian + conda).
+_NODE_RUNTIME = (
+    "RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git && \\\n"
+    "    (command -v node >/dev/null 2>&1 || \\\n"
+    "      (curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \\\n"
+    "       apt-get install -y --no-install-recommends nodejs)) && \\\n"
+    "    rm -rf /var/lib/apt/lists/*"
+)
+
+
+@dataclass(frozen=True)
+class AgentLayer:
+    """How to install and invoke one agent inside the rendered image.
+
+    ``run`` is the in-container command; it reads the task prompt from ``CAPTURE/prompt.txt``
+    and runs non-interactively in ``/testbed``. ``env`` points the agent's session/home at
+    ``CAPTURE`` so the native trace lands on the mounted host dir; ``session_glob`` finds it.
+    ``model_flag`` is the CLI flag used to pin teich's configured model (all current agents
+    use ``--model``); ``_run_command`` appends ``<model_flag> <model>`` so the container runs
+    teich's model rather than each CLI's own default.
+    """
+
+    provider: str
+    runtime_install: str
+    agent_install: str
+    env: dict[str, str] = field(default_factory=dict)
+    session_glob: str = "**/*.jsonl"
+    run: str = ""
+    model_flag: str = "--model"
+
+
+_PROMPT = f"$(cat {CAPTURE}/prompt.txt)"
+
+# Per-provider recipes mirror teich's own non-interactive agent invocations. The exact CLI
+# flags + session locations are what the Docker integration pass validates.
+_LAYERS: dict[str, AgentLayer] = {
+    "pi": AgentLayer(
+        provider="pi",
+        runtime_install=_NODE_RUNTIME,
+        agent_install="RUN npm install -g @mariozechner/pi-coding-agent",
+        env={"PI_SESSION_DIR": f"{CAPTURE}/sessions"},
+        session_glob="sessions/**/*.jsonl",
+        run=f'pi --yolo --print "{_PROMPT}"',
+    ),
+    "codex": AgentLayer(
+        provider="codex",
+        runtime_install=_NODE_RUNTIME,
+        agent_install="RUN npm install -g @openai/codex",
+        env={"CODEX_HOME": f"{CAPTURE}/codex"},
+        session_glob="codex/sessions/**/*.jsonl",
+        run=f'codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox "{_PROMPT}"',
+    ),
+    "claude-code": AgentLayer(
+        provider="claude-code",
+        runtime_install=_NODE_RUNTIME,
+        agent_install="RUN npm install -g @anthropic-ai/claude-code",
+        env={"CLAUDE_CONFIG_DIR": f"{CAPTURE}/claude"},
+        session_glob="claude/projects/**/*.jsonl",
+        run=f'claude -p "{_PROMPT}" --output-format stream-json --verbose --dangerously-skip-permissions',
+    ),
+}
+
+# teich provider aliases -> the swe-bench layer key.
+_PROVIDER_ALIASES = {"claude": "claude-code", "claude_code": "claude-code"}
+
+
+def _agent_layer(cfg: Config) -> AgentLayer:
+    provider = cfg.get_agent_provider().strip().lower()
+    key = _PROVIDER_ALIASES.get(provider, provider)
+    layer = _LAYERS.get(key)
+    if layer is None:
+        raise RuntimeError(
+            f"The swe-bench backend does not support agent provider {provider!r}; "
+            f"use one of: {', '.join(sorted(_LAYERS))}."
+        )
+    return layer
+
+
+def _model_name(cfg: Config) -> str:
+    """Model for the in-container agent, with the pi ``<provider>/<model>`` prefix when needed.
+
+    Mirrors the harbor backend's prefix rule: pi splits ``<provider>/<model>`` to pick the
+    credential env var, so ``model: z-ai/glm-5.2`` + ``api.provider: openrouter`` becomes
+    ``openrouter/z-ai/glm-5.2``.
+    """
+    model = cfg.get_effective_model().strip()
+    if not model:
+        return model
+    api_provider = (cfg.api.provider or "").strip()
+    if cfg.get_agent_provider() == "pi" and api_provider and not model.startswith(f"{api_provider}/"):
+        return f"{api_provider}/{model}"
+    return model
+
+
+def _run_command(cfg: Config, layer: AgentLayer) -> str:
+    """The agent's in-container command, with teich's configured model pinned when set."""
+    model = _model_name(cfg)
+    if not model:
+        return layer.run
+    return f"{layer.run} {layer.model_flag} {shlex.quote(model)}"
+
+
+def _auth_env(cfg: Config) -> dict[str, str]:
+    """Model credentials for the in-container agent, mirroring the harbor backend.
+
+    An ``anthropic`` project sets ``ANTHROPIC_API_KEY`` only (not shadowed under
+    ``OPENAI_API_KEY``); otherwise the key goes to ``OPENAI_API_KEY`` plus
+    ``OPENROUTER_API_KEY`` for an OpenRouter project.
+    """
+    env: dict[str, str] = {}
+    api_key = cfg.get_api_key()
+    if api_key:
+        if cfg.api.provider == "anthropic":
+            env["ANTHROPIC_API_KEY"] = api_key
+        else:
+            env["OPENAI_API_KEY"] = api_key
+            if cfg.api.provider == "openrouter":
+                env["OPENROUTER_API_KEY"] = api_key
+    base_url = cfg.get_base_url()
+    if base_url:
+        env["OPENAI_BASE_URL"] = base_url
+    return env
+
+
+def render_agent_dockerfile(
+    base_image: str, layer: AgentLayer, *, langfuse: bool = False, langfuse_install: str = ""
+) -> str:
+    """Render the agent-layer Dockerfile (FROM the instance image) from the Jinja template."""
+    from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+    env = Environment(
+        loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    template = env.get_template("agent.dockerfile.j2")
+    return template.render(
+        base_image=base_image,
+        provider=layer.provider,
+        runtime_install=layer.runtime_install,
+        agent_install=layer.agent_install,
+        langfuse=langfuse,
+        langfuse_install=langfuse_install,
+    )
+
+
+# --------------------------------------------------------------------------- dataset
+
+
+def _load_instances(source: BenchSource) -> list[dict[str, Any]]:
+    """Load SWE-bench instances for a source (HF dataset id or a local json/jsonl path)."""
+    from swebench.harness.utils import load_swebench_dataset
+
+    split = source.split or "test"
+    instance_ids = list(source.instances) if source.instances else None
+    try:
+        dataset = load_swebench_dataset(source.source, split, instance_ids)
+    except Exception as exc:  # bad name/split/ids, network, HF auth -> a clean bench error
+        raise RuntimeError(
+            f"Failed to load swe-bench dataset {source.source!r} (split {split!r}): "
+            f"{type(exc).__name__}: {exc}."
+        ) from exc
+    return [dict(instance) for instance in dataset]
+
+
+# --------------------------------------------------------------------------- rewards
+
+
+def _rewards_from_report(entry: dict[str, Any]) -> dict[str, float]:
+    """Map one swebench report entry to a rewards dict (``reward`` = resolved, for routing)."""
+    resolved = 1.0 if entry.get("resolved") else 0.0
+    rewards: dict[str, float] = {
+        "reward": resolved,
+        "resolved": resolved,
+        "patch_applied": 1.0 if entry.get("patch_successfully_applied") else 0.0,
+    }
+    tests = entry.get("tests_status")
+    if isinstance(tests, dict):
+        for key, name in (("FAIL_TO_PASS", "fail_to_pass"), ("PASS_TO_PASS", "pass_to_pass")):
+            group = tests.get(key)
+            if isinstance(group, dict):
+                passed = len(group.get("success") or [])
+                failed = len(group.get("failure") or [])
+                if passed + failed:
+                    rewards[name] = passed / (passed + failed)
+    return rewards
+
+
+# ----------------------------------------------------------------- docker seam (integration)
+
+
+def _docker(args: list[str], *, timeout: int | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", *args], capture_output=True, text=True, timeout=timeout, check=check
+    )
+
+
+def _ensure_instance_image(spec: Any, *, namespace: str | None, timeout: int | None = None) -> None:
+    """Make the swebench instance image available locally (pull remote, else build)."""
+    image = spec.instance_image_key
+    if _docker(["images", "-q", image], check=False).stdout.strip():
+        return
+    if namespace:  # remote (published) image -> pull it
+        _docker(["pull", image], timeout=timeout)
+        return
+    import docker  # local build path
+    from swebench.harness.docker_build import build_instance_images
+
+    build_instance_images(docker.from_env(), [spec], namespace=None, max_workers=1)
+
+
+def _build_image(dockerfile: str, tag: str, *, timeout: int | None = None) -> None:
+    # Build from stdin (no Dockerfile written into the repo/context); capture logs and bound the
+    # build by the run timeout, surfacing the tail on failure instead of flooding stdout.
+    try:
+        subprocess.run(
+            ["docker", "build", "-t", tag, "-"],
+            input=dockerfile, text=True, capture_output=True, check=True, timeout=timeout,
+        )
+    except subprocess.CalledProcessError as exc:
+        tail = (exc.stderr or exc.stdout or "")[-2000:]
+        raise RuntimeError(f"docker build for {tag} failed:\n{tail}") from exc
+
+
+def _native_trace(capture_dir: Path, session_glob: str) -> tuple[list[str], Path | None]:
+    """Collect the agent's native session JSONL from the mounted capture dir."""
+    files = sorted(capture_dir.glob(session_glob))
+    lines = [
+        line
+        for path in files
+        if path.is_file()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    if not lines:
+        return [], None
+    return lines, files[0].parent
+
+
+def _run_agent(
+    cfg: Config, source: BenchSource, instance: dict[str, Any], spec: Any,
+    layer: AgentLayer, capture_dir: Path,
+) -> tuple[list[str], Path | None, str]:
+    """Build the agent layer, run the agent on the problem, return (trace, dir, model_patch)."""
+    # Reset the per-task capture dir: it's a stable path (keyed by source+task.id), so a rerun
+    # that aborts before writing a fresh session/model.patch would otherwise harvest and grade
+    # the previous attempt's stale artifacts.
+    if capture_dir.exists():
+        shutil.rmtree(capture_dir)
+    capture_dir.mkdir(parents=True, exist_ok=True)
+    (capture_dir / "prompt.txt").write_text(instance.get("problem_statement") or "", encoding="utf-8")
+
+    # Namespace all scratch (image tag, container, env-file) by source so two sources that
+    # contain the same instance can't collide under concurrency; lowercased for Docker.
+    key = base.slug(f"{base.source_id(source)}-{instance['instance_id']}").lower()
+    # Langfuse is intentionally not wired here (guarded against in tasks()); render it off so
+    # the image never carries a phantom tracing block.
+    dockerfile = render_agent_dockerfile(spec.instance_image_key, layer)
+    agent_image = f"teich-swe-{key}:latest"
+    timeout = cfg.timeout_seconds if cfg.timeout_seconds and cfg.timeout_seconds > 0 else None
+    _build_image(dockerfile, agent_image, timeout=timeout)
+
+    # Pass credentials via an env-file (host-only, outside the mounted dir, mode 0600) rather
+    # than `-e KEY=VALUE`, so keys aren't visible in the host process list. Note: they still
+    # become container env vars (readable via `docker inspect` / inside the container), so this
+    # guards the host's `ps`, not a hostile Docker-socket user.
+    env = {**layer.env, **_auth_env(cfg)}
+    env_file = capture_dir.parent / f"{key}.env"
+    fd = os.open(env_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(fd, 0o600)  # O_CREAT's mode only applies on create (and is umask-masked); enforce 0600 either way
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write("".join(f"{name}={value}\n" for name, value in env.items()))
+
+    container = f"teich-swe-{key}"
+    capture = f"{CAPTURE}/model.patch"
+    run = _run_command(cfg, layer)
+    shell = (
+        f"cd {TESTBED} && ({run} || true) && git -C {TESTBED} add -A && "
+        f"git -C {TESTBED} diff --cached --no-color > {capture} 2>/dev/null || true"
+    )
+    cmd = [
+        "docker", "run", "--rm", "--name", container, "--env-file", str(env_file),
+        "-v", f"{capture_dir}:{CAPTURE}",
+        agent_image, "bash", "-lc", shell,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+    except subprocess.TimeoutExpired:
+        _docker(["rm", "-f", container], check=False)  # reap the named container, then fail the task
+        raise
+    finally:
+        env_file.unlink(missing_ok=True)
+        # Remove the per-task agent-layer image so it doesn't accumulate (the shared swebench
+        # instance image is left in place — it's reused and expensive to re-pull). Best-effort:
+        # check=False only swallows non-zero exits, so a missing docker / hang must not mask the
+        # real task result during this finally.
+        if not cfg.output.keep_bench_images:
+            try:
+                _docker(["rmi", "-f", agent_image], timeout=30, check=False)
+            except Exception:
+                pass
+    if result.returncode != 0:
+        # The shell masks the *agent's* exit with `|| true`, so a non-zero exit here is a Docker/
+        # infra failure — fail the task rather than grade an empty patch as a real result.
+        raise RuntimeError(
+            f"docker run failed for {container} (exit {result.returncode}): "
+            f"{(result.stderr or result.stdout or '').strip()[-1000:]}"
+        )
+
+    patch_file = capture_dir / "model.patch"
+    model_patch = patch_file.read_text(encoding="utf-8") if patch_file.is_file() else ""
+    lines, native_dir = _native_trace(capture_dir, layer.session_glob)
+    return lines, native_dir, model_patch
+
+
+def _grade(cfg: Config, instance: dict[str, Any], spec: Any, model_patch: str) -> dict[str, Any]:
+    """Grade a candidate patch with swebench's harness; return the report entry for the instance."""
+    import docker
+    from swebench.harness.constants import RUN_EVALUATION_LOG_DIR
+    from swebench.harness.run_evaluation import run_instance
+
+    instance_id = instance["instance_id"]
+    model_name = "teich"
+    run_id = f"teich-{base.slug(instance_id)}"
+    prediction = {
+        "instance_id": instance_id,
+        "model_name_or_path": model_name,
+        "model_patch": model_patch,
+    }
+    timeout = cfg.timeout_seconds if cfg.timeout_seconds and cfg.timeout_seconds > 0 else None
+    report_path = (
+        Path(RUN_EVALUATION_LOG_DIR) / run_id / model_name / instance_id / "report.json"
+    )
+    # run_id is deterministic, so drop any prior report first: if this rerun fails before
+    # writing a fresh one, we must not grade off a stale verdict from a previous attempt.
+    report_path.unlink(missing_ok=True)
+    run_instance(
+        spec, prediction, rm_image=False, force_rebuild=False,
+        client=docker.from_env(), run_id=run_id, timeout=timeout,
+    )
+    if not report_path.is_file():
+        return {"resolved": False, "patch_successfully_applied": bool(model_patch)}
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    return report.get(instance_id, {"resolved": False})
+
+
+# --------------------------------------------------------------------------- backend
+
+
+class SweBenchBackend:
+    """Runs teich's agent against SWE-bench instances and grades the diff with swebench."""
+
+    type = "swe-bench"
+
+    def require(self) -> None:
+        if sys.version_info < (3, 10):
+            raise RuntimeError(
+                "The swe-bench bench backend requires Python 3.10+ "
+                f"(current: {sys.version_info.major}.{sys.version_info.minor}). {SWE_INSTALL_HINT}"
+            )
+        try:
+            import swebench  # noqa: F401
+        except ImportError as exc:  # pragma: no cover - only without the extra
+            raise RuntimeError(SWE_INSTALL_HINT) from exc
+
+    def tasks(self, cfg: Config, source: BenchSource, *, refresh: bool = False) -> list[base.BenchTask]:
+        # refresh is a no-op here: HF datasets handle their own cache.
+        if cfg.agent.langfuse.enabled:
+            # The swe-bench backend does not wire Langfuse into the agent container (no
+            # creds in the env-file, no install layer), so tracing would silently no-op.
+            # Fail loudly rather than pretend support.
+            raise RuntimeError(
+                "The swe-bench bench backend does not support Langfuse tracing; "
+                "set agent.langfuse.enabled = false for swe-bench sources."
+            )
+        return [
+            base.BenchTask(id=instance["instance_id"], raw=instance)
+            for instance in _load_instances(source)
+        ]
+
+    def run(self, cfg: Config, source: BenchSource, task: base.BenchTask) -> base.BenchRun:
+        from swebench.harness.test_spec.test_spec import make_test_spec
+
+        instance = task.raw
+        layer = _agent_layer(cfg)  # fail fast on an unsupported provider, before any Docker work
+        namespace = DEFAULT_NAMESPACE
+        spec = make_test_spec(instance, namespace=namespace)
+        timeout = cfg.timeout_seconds if cfg.timeout_seconds and cfg.timeout_seconds > 0 else None
+        _ensure_instance_image(spec, namespace=namespace, timeout=timeout)
+
+        capture_dir = base.bench_root(cfg) / "swe" / base.bench_stem(source, task.id)
+        lines, native_dir, model_patch = _run_agent(cfg, source, instance, spec, layer, capture_dir)
+
+        entry = _grade(cfg, instance, spec, model_patch)
+        rewards = _rewards_from_report(entry)
+        metadata = {
+            "instance_id": task.id,
+            "repo": instance.get("repo"),
+            "base_commit": instance.get("base_commit"),
+            "model_patch": model_patch,
+            "patch_applied": bool(entry.get("patch_successfully_applied")),
+            **base.trace_metadata(native_dir),
+        }
+        return base.BenchRun(native_lines=lines, rewards=rewards, metadata=metadata)

--- a/src/teich/bench/backends/swebench.py
+++ b/src/teich/bench/backends/swebench.py
@@ -121,6 +121,17 @@ def _agent_layer(cfg: Config) -> AgentLayer:
             f"The swe-bench backend does not support agent provider {provider!r}; "
             f"use one of: {', '.join(sorted(_LAYERS))}."
         )
+    # The claude-code layer runs the Anthropic ``claude`` CLI, which authenticates via
+    # ``ANTHROPIC_*``; ``_auth_env`` only seeds those for an ``anthropic`` project. With any other
+    # api.provider the container has no usable Claude credentials, so the run would silently
+    # produce empty traces — fail fast instead. (Routing Claude through an OpenRouter/OpenAI proxy
+    # is the larger prompt-mode-parity follow-up.)
+    if layer.provider == "claude-code" and cfg.api.provider != "anthropic":
+        raise RuntimeError(
+            "The swe-bench claude-code agent runs the Anthropic `claude` CLI, which needs an "
+            f"anthropic-provider config; api.provider is {cfg.api.provider!r}. Set api.provider: "
+            "anthropic for swe-bench claude-code runs, or use a different agent provider."
+        )
     return layer
 
 

--- a/src/teich/bench/backends/swebench.py
+++ b/src/teich/bench/backends/swebench.py
@@ -35,9 +35,9 @@ SWE_INSTALL_HINT = (
     "`pip install 'teich[swe]'` (requires Python 3.10+)."
 )
 
-# SWE-bench publishes prebuilt instance images under this Docker namespace; using them
-# means we pull one image and add a thin agent layer instead of rebuilding base+env+instance.
-DEFAULT_NAMESPACE = "swebench"
+# SWE-bench publishes prebuilt instance images under the "swebench" Docker namespace (the
+# per-source default): we pull one image and add a thin agent layer instead of rebuilding
+# base+env+instance. A source with ``namespace: null`` builds instance images locally instead.
 TESTBED = "/testbed"  # swebench DOCKER_WORKDIR: the repo @ base_commit lives here
 CAPTURE = "/teich-out"  # mounted host dir for the prompt, the agent session, and the diff
 
@@ -446,7 +446,9 @@ class SweBenchBackend:
 
         instance = task.raw
         layer = _agent_layer(cfg)  # fail fast on an unsupported provider, before any Docker work
-        namespace = DEFAULT_NAMESPACE
+        # Default "swebench" pulls the published instance image; namespace=None builds it locally
+        # (make_test_spec + _ensure_instance_image both honor it), needed for custom instances.
+        namespace = source.namespace
         spec = make_test_spec(instance, namespace=namespace)
         timeout = cfg.timeout_seconds if cfg.timeout_seconds and cfg.timeout_seconds > 0 else None
         _ensure_instance_image(spec, namespace=namespace, timeout=timeout)

--- a/src/teich/bench/runner.py
+++ b/src/teich/bench/runner.py
@@ -17,6 +17,10 @@ from .backends import BenchTask, base, get_backend
 if TYPE_CHECKING:
     from ..config import BenchSource, Config
 
+# api.wire_api values that mean "chat completions" (mirrors runner._pi_provider_api); anything
+# else (e.g. "responses") is the OpenAI Responses API, which the bench agents default to.
+_CHAT_WIRE_APIS = {"completions", "chat_completions", "chat-completions", "openai-completions"}
+
 
 class _BenchProgress:
     """Live per-source progress bar for bench runs (rich); a no-op when not a terminal.
@@ -116,6 +120,23 @@ def run_bench(
         raise RuntimeError(
             "bench mode does not yet support Codex host auth (agent.codex.use_host_auth). "
             "Configure an API key for the run, or disable use_host_auth."
+        )
+
+    # Unlike prompt mode, bench doesn't thread api.wire_api into the agent (no codex config, no pi
+    # provider_settings), so a chat-completions-only endpoint isn't honored: pi/codex default to the
+    # Responses API and hit /responses on e.g. api.z.ai, which silently fails. openrouter is exempt
+    # (its own model-prefix routing already selects completions). Fail fast instead of ignoring it.
+    _provider = cfg.api.provider.strip().lower()
+    if (
+        cfg.get_agent_provider() in ("codex", "pi")
+        and _provider != "openrouter"
+        and cfg.api.wire_api.strip().lower() in _CHAT_WIRE_APIS
+    ):
+        raise RuntimeError(
+            "bench mode does not yet thread api.wire_api into the agent, so a chat-completions-only "
+            f"endpoint won't be honored (api.wire_api={cfg.api.wire_api!r}, api.provider={_provider!r}, "
+            f"agent={cfg.get_agent_provider()!r}); the agent would default to the Responses API. "
+            "Use api.provider: openrouter, or api.wire_api: responses against a Responses-API endpoint."
         )
 
     def out(message: str) -> None:

--- a/src/teich/bench/runner.py
+++ b/src/teich/bench/runner.py
@@ -53,6 +53,7 @@ def run_bench(
 
     max_workers = max(1, int(cfg.max_concurrency))
     written: list[Path] = []
+    attempted = 0
 
     def record(task: BenchTask, run: base.BenchRun, src: BenchSource) -> None:
         if not run.native_lines:
@@ -86,6 +87,7 @@ def run_bench(
         )
         if not pending:
             continue
+        attempted += len(pending)
 
         # Bind src + the bound run method as defaults so the closure doesn't capture the
         # loop variables by reference (ruff B023).
@@ -135,4 +137,14 @@ def run_bench(
             raise
         finally:
             pool.shutdown(wait=not interrupted, cancel_futures=interrupted)
+
+    # Per-task failures are swallowed (skipped) above; if every dispatched task failed we'd
+    # otherwise return an empty list and the CLI would exit 0 — a misconfigured run then looks
+    # like a successful empty benchmark in automation. Distinguish it from a legitimately empty
+    # run (nothing dispatched / all resume-skipped, which keeps `written` populated).
+    if attempted and not written:
+        raise RuntimeError(
+            f"bench: all {attempted} attempted task(s) failed; no rows were harvested "
+            "(see the per-task errors above)."
+        )
     return written

--- a/src/teich/bench/runner.py
+++ b/src/teich/bench/runner.py
@@ -1,0 +1,129 @@
+"""Drive ``teich generate --mode bench``.
+
+A thin loop over ``cfg.bench.sources``: each source declares a ``type`` (harbor,
+swe-bench), resolved to a backend that turns tasks into native traces + rewards; the
+shared harvest (``backends.base.harvest``) routes each into passed/failed/borderline and
+writes a per-task ``metadata/`` sidecar. Backends are the only thing that differs per type.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .backends import BenchTask, base, get_backend
+
+if TYPE_CHECKING:
+    from ..config import BenchSource, Config
+
+
+def run_bench(
+    cfg: Config, *, console: Any = None, resume: bool = False, refresh: bool = False
+) -> list[Path]:
+    """Run every configured bench source through its backend and harvest reward-labeled traces.
+
+    Tasks within a source run through a bounded pool of size ``cfg.max_concurrency`` (default 1);
+    each task is isolated (its own container + per-task output files), the resume-skip is checked
+    before dispatch, and the harvest runs on the main thread as results complete. Backends honor
+    ``cfg.timeout_seconds`` on their own container runs.
+    """
+    sources = cfg.bench.sources
+    if not sources:
+        raise RuntimeError(
+            "--mode bench requires at least one entry in bench.sources, e.g.\n"
+            "  bench:\n"
+            "    sources:\n"
+            "      - { type: harbor, source: terminal-bench@2.0 }\n"
+            "      - { type: swe-bench, source: SWE-bench/SWE-bench_Verified }"
+        )
+
+    def out(message: str) -> None:
+        if console is not None:
+            console.print(message)
+
+    max_workers = max(1, int(cfg.max_concurrency))
+    written: list[Path] = []
+
+    def record(task: BenchTask, run: base.BenchRun, src: BenchSource) -> None:
+        if not run.native_lines:
+            out(f"[yellow]bench: no trace harvested for {task.id}[/yellow]")
+            return
+        paths, split = base.harvest(cfg, src, task, run)
+        primary = base.primary_score(run.rewards)
+        score = f"reward={primary:g}" if primary is not None else "unscored"
+        out(f"[green]bench: {task.id}: {split} ({score})[/green]")
+        written.extend(paths)
+
+    interrupt_hint = "Re-run with --resume to continue from where it stopped."
+    for source in sources:
+        backend = get_backend(source.type)
+        backend.require()
+        # Source-level errors (bad spec, download failure) abort the run.
+        tasks = list(backend.tasks(cfg, source, refresh=refresh))
+
+        pending: list[BenchTask] = []
+        for task in tasks:
+            if resume:
+                existing = base.existing_output(cfg, base.bench_stem(source, task.id))
+                if existing is not None:
+                    out(f"[yellow]bench: skipping {task.id} (already harvested)[/yellow]")
+                    written.append(existing)
+                    continue
+            pending.append(task)
+        out(
+            f"[blue]bench[{source.type}]: {source.source} -> {len(pending)} task(s) "
+            f"(concurrency {max_workers})[/blue]"
+        )
+        if not pending:
+            continue
+
+        # Bind src + the bound run method as defaults so the closure doesn't capture the
+        # loop variables by reference (ruff B023).
+        def _run(
+            task: BenchTask, src: BenchSource = source, run=backend.run
+        ) -> tuple[BenchTask, base.BenchRun]:
+            return task, run(cfg, src, task)
+
+        if max_workers == 1:
+            # Single worker: run inline on the main thread so Ctrl-C propagates straight into
+            # the agent/Docker call and stops it. A thread pool would move the work off the
+            # main thread, where SIGINT can't reach it, so the container would keep running.
+            try:
+                for task in pending:
+                    try:
+                        _, run = _run(task)
+                    except Exception as exc:  # one task's failure (docker/agent/grade) — skip it
+                        out(f"[red]bench: {task.id}: failed ({type(exc).__name__}: {exc})[/red]")
+                        continue
+                    record(task, run, source)
+            except KeyboardInterrupt:
+                out(f"[red]bench: interrupted. {interrupt_hint}[/red]")
+                raise
+            continue
+
+        # Bounded concurrency: harvest on the main thread as results complete. On Ctrl-C, drop
+        # the queued tasks immediately (cancel_futures); workers already inside a Docker call
+        # can't be signalled, so those few finish before the process exits.
+        pool = ThreadPoolExecutor(max_workers=max_workers)
+        interrupted = False
+        try:
+            futures = {pool.submit(_run, task): task for task in pending}
+            for future in as_completed(futures):
+                task = futures[future]
+                try:
+                    _, run = future.result()
+                except Exception as exc:  # one task's failure (docker/agent/grade) — skip it
+                    out(f"[red]bench: {task.id}: failed ({type(exc).__name__}: {exc})[/red]")
+                    continue
+                record(task, run, source)
+        except KeyboardInterrupt:
+            interrupted = True
+            out(
+                "[red]bench: interrupt — cancelling queued tasks; in-flight containers will "
+                f"finish before exit. {interrupt_hint}[/red]"
+            )
+            raise
+        finally:
+            pool.shutdown(wait=not interrupted, cancel_futures=interrupted)
+    return written

--- a/src/teich/bench/runner.py
+++ b/src/teich/bench/runner.py
@@ -18,6 +18,77 @@ if TYPE_CHECKING:
     from ..config import BenchSource, Config
 
 
+class _BenchProgress:
+    """Live per-source progress bar for bench runs (rich); a no-op when not a terminal.
+
+    Bench tasks are coarse (one container per task, minutes each), so this shows a per-source
+    bar with an M/N count and a running passed/failed/borderline tally rather than prompt mode's
+    per-session table. Counts are tracked even when the bar is disabled (non-terminal / no
+    console) so the logic is testable; printing via the caller's ``out`` interleaves above the
+    live bars. It never installs a signal handler, so the Ctrl-C handling in ``run_bench`` is
+    unaffected.
+    """
+
+    def __init__(self, console: Any):
+        self._console = console
+        self.enabled = bool(console is not None and getattr(console, "is_terminal", False))
+        self._progress: Any = None
+        self.passed = self.failed = self.borderline = self.errored = 0
+
+    def __enter__(self) -> _BenchProgress:
+        if self.enabled:
+            from rich.progress import (
+                BarColumn,
+                MofNCompleteColumn,
+                Progress,
+                SpinnerColumn,
+                TextColumn,
+                TimeElapsedColumn,
+            )
+
+            self._progress = Progress(
+                SpinnerColumn(),
+                TextColumn("[bold blue]{task.description}"),
+                BarColumn(),
+                MofNCompleteColumn(),
+                TextColumn("{task.fields[tally]}"),
+                TimeElapsedColumn(),
+                console=self._console,
+            )
+            self._progress.__enter__()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        if self._progress is not None:
+            self._progress.__exit__(*exc)
+            self._progress = None
+
+    def add_source(self, label: str, total: int) -> Any:
+        """Start a bar for one source; returns an opaque handle (None when disabled)."""
+        return self._progress.add_task(label, total=total, tally="") if self._progress else None
+
+    def _tally(self) -> str:
+        parts = []
+        if self.passed:
+            parts.append(f"[green]{self.passed}✓[/green]")
+        if self.failed:
+            parts.append(f"[red]{self.failed}✗[/red]")
+        if self.borderline:
+            parts.append(f"[yellow]{self.borderline}~[/yellow]")
+        if self.errored:
+            parts.append(f"[red]{self.errored}![/red]")
+        return " ".join(parts)
+
+    def advance(self, bar: Any, *, split: str | None = None, errored: bool = False) -> None:
+        """Mark one task done: bump the split/error tally and advance its source bar."""
+        if errored:
+            self.errored += 1
+        elif split in ("passed", "failed", "borderline"):
+            setattr(self, split, getattr(self, split) + 1)
+        if self._progress is not None and bar is not None:
+            self._progress.update(bar, advance=1, tally=self._tally())
+
+
 def run_bench(
     cfg: Config, *, console: Any = None, resume: bool = False, refresh: bool = False
 ) -> list[Path]:
@@ -54,89 +125,97 @@ def run_bench(
     max_workers = max(1, int(cfg.max_concurrency))
     written: list[Path] = []
     attempted = 0
-
-    def record(task: BenchTask, run: base.BenchRun, src: BenchSource) -> None:
-        if not run.native_lines:
-            out(f"[yellow]bench: no trace harvested for {task.id}[/yellow]")
-            return
-        paths, split = base.harvest(cfg, src, task, run)
-        primary = base.primary_score(run.rewards)
-        score = f"reward={primary:g}" if primary is not None else "unscored"
-        out(f"[green]bench: {task.id}: {split} ({score})[/green]")
-        written.extend(paths)
-
     interrupt_hint = "Re-run with --resume to continue from where it stopped."
-    for source in sources:
-        backend = get_backend(source.type)
-        backend.require()
-        # Source-level errors (bad spec, download failure) abort the run.
-        tasks = list(backend.tasks(cfg, source, refresh=refresh))
 
-        pending: list[BenchTask] = []
-        for task in tasks:
-            if resume:
-                existing = base.existing_output(cfg, base.bench_stem(source, task.id))
-                if existing is not None:
-                    out(f"[yellow]bench: skipping {task.id} (already harvested)[/yellow]")
-                    written.append(existing)
-                    continue
-            pending.append(task)
-        out(
-            f"[blue]bench[{source.type}]: {source.source} -> {len(pending)} task(s) "
-            f"(concurrency {max_workers})[/blue]"
-        )
-        if not pending:
-            continue
-        attempted += len(pending)
+    with _BenchProgress(console) as progress:
 
-        # Bind src + the bound run method as defaults so the closure doesn't capture the
-        # loop variables by reference (ruff B023).
-        def _run(
-            task: BenchTask, src: BenchSource = source, run=backend.run
-        ) -> tuple[BenchTask, base.BenchRun]:
-            return task, run(cfg, src, task)
+        def record(task: BenchTask, run: base.BenchRun, src: BenchSource) -> str | None:
+            """Harvest a task's trace; return its split (None if nothing was harvested)."""
+            if not run.native_lines:
+                out(f"[yellow]bench: no trace harvested for {task.id}[/yellow]")
+                return None
+            paths, split = base.harvest(cfg, src, task, run)
+            written.extend(paths)
+            if not progress.enabled:  # the live bar's tally already conveys per-task outcomes
+                primary = base.primary_score(run.rewards)
+                score = f"reward={primary:g}" if primary is not None else "unscored"
+                out(f"[green]bench: {task.id}: {split} ({score})[/green]")
+            return split
 
-        if max_workers == 1:
-            # Single worker: run inline on the main thread so Ctrl-C propagates straight into
-            # the agent/Docker call and stops it. A thread pool would move the work off the
-            # main thread, where SIGINT can't reach it, so the container would keep running.
+        for source in sources:
+            backend = get_backend(source.type)
+            backend.require()
+            # Source-level errors (bad spec, download failure) abort the run.
+            tasks = list(backend.tasks(cfg, source, refresh=refresh))
+
+            pending: list[BenchTask] = []
+            for task in tasks:
+                if resume:
+                    existing = base.existing_output(cfg, base.bench_stem(source, task.id))
+                    if existing is not None:
+                        out(f"[yellow]bench: skipping {task.id} (already harvested)[/yellow]")
+                        written.append(existing)
+                        continue
+                pending.append(task)
+            out(
+                f"[blue]bench[{source.type}]: {source.source} -> {len(pending)} task(s) "
+                f"(concurrency {max_workers})[/blue]"
+            )
+            if not pending:
+                continue
+            attempted += len(pending)
+            bar = progress.add_source(f"{source.type}: {source.source}", len(pending))
+
+            # Bind src + the bound run method as defaults so the closure doesn't capture the
+            # loop variables by reference (ruff B023).
+            def _run(
+                task: BenchTask, src: BenchSource = source, run=backend.run
+            ) -> tuple[BenchTask, base.BenchRun]:
+                return task, run(cfg, src, task)
+
+            if max_workers == 1:
+                # Single worker: run inline on the main thread so Ctrl-C propagates straight into
+                # the agent/Docker call and stops it. A thread pool would move the work off the
+                # main thread, where SIGINT can't reach it, so the container would keep running.
+                try:
+                    for task in pending:
+                        try:
+                            _, run = _run(task)
+                        except Exception as exc:  # one task's failure (docker/agent/grade) — skip it
+                            progress.advance(bar, errored=True)
+                            out(f"[red]bench: {task.id}: failed ({type(exc).__name__}: {exc})[/red]")
+                            continue
+                        progress.advance(bar, split=record(task, run, source))
+                except KeyboardInterrupt:
+                    out(f"[red]bench: interrupted. {interrupt_hint}[/red]")
+                    raise
+                continue
+
+            # Bounded concurrency: harvest on the main thread as results complete. On Ctrl-C, drop
+            # the queued tasks immediately (cancel_futures); workers already inside a Docker call
+            # can't be signalled, so those few finish before the process exits.
+            pool = ThreadPoolExecutor(max_workers=max_workers)
+            interrupted = False
             try:
-                for task in pending:
+                futures = {pool.submit(_run, task): task for task in pending}
+                for future in as_completed(futures):
+                    task = futures[future]
                     try:
-                        _, run = _run(task)
+                        _, run = future.result()
                     except Exception as exc:  # one task's failure (docker/agent/grade) — skip it
+                        progress.advance(bar, errored=True)
                         out(f"[red]bench: {task.id}: failed ({type(exc).__name__}: {exc})[/red]")
                         continue
-                    record(task, run, source)
+                    progress.advance(bar, split=record(task, run, source))
             except KeyboardInterrupt:
-                out(f"[red]bench: interrupted. {interrupt_hint}[/red]")
+                interrupted = True
+                out(
+                    "[red]bench: interrupt — cancelling queued tasks; in-flight containers will "
+                    f"finish before exit. {interrupt_hint}[/red]"
+                )
                 raise
-            continue
-
-        # Bounded concurrency: harvest on the main thread as results complete. On Ctrl-C, drop
-        # the queued tasks immediately (cancel_futures); workers already inside a Docker call
-        # can't be signalled, so those few finish before the process exits.
-        pool = ThreadPoolExecutor(max_workers=max_workers)
-        interrupted = False
-        try:
-            futures = {pool.submit(_run, task): task for task in pending}
-            for future in as_completed(futures):
-                task = futures[future]
-                try:
-                    _, run = future.result()
-                except Exception as exc:  # one task's failure (docker/agent/grade) — skip it
-                    out(f"[red]bench: {task.id}: failed ({type(exc).__name__}: {exc})[/red]")
-                    continue
-                record(task, run, source)
-        except KeyboardInterrupt:
-            interrupted = True
-            out(
-                "[red]bench: interrupt — cancelling queued tasks; in-flight containers will "
-                f"finish before exit. {interrupt_hint}[/red]"
-            )
-            raise
-        finally:
-            pool.shutdown(wait=not interrupted, cancel_futures=interrupted)
+            finally:
+                pool.shutdown(wait=not interrupted, cancel_futures=interrupted)
 
     # Per-task failures are swallowed (skipped) above; if every dispatched task failed we'd
     # otherwise return an empty list and the CLI would exit 0 — a misconfigured run then looks

--- a/src/teich/bench/runner.py
+++ b/src/teich/bench/runner.py
@@ -38,6 +38,15 @@ def run_bench(
             "      - { type: swe-bench, source: SWE-bench/SWE-bench_Verified }"
         )
 
+    # Bench backends don't yet seed the Codex host-auth snapshot / token broker into the task
+    # containers (unlike prompt mode). Fail fast rather than launch a silently-unauthenticated
+    # run when host auth is the only credential configured.
+    if cfg.get_agent_provider() == "codex" and cfg.agent.codex.use_host_auth and not cfg.get_api_key():
+        raise RuntimeError(
+            "bench mode does not yet support Codex host auth (agent.codex.use_host_auth). "
+            "Configure an API key for the run, or disable use_host_auth."
+        )
+
     def out(message: str) -> None:
         if console is not None:
             console.print(message)

--- a/src/teich/bench/templates/agent.dockerfile.j2
+++ b/src/teich/bench/templates/agent.dockerfile.j2
@@ -1,0 +1,26 @@
+{#- Teich SWE-bench agent layer.
+
+    Rendered on top of a SWE-bench *instance* image (which already has the repo
+    checked out at base_commit in /testbed with its deps installed) so a teich agent
+    can edit /testbed. The agent's git diff becomes the candidate patch, which swebench
+    then grades. Generated file — do not edit by hand; change agent.dockerfile.j2.
+
+    Vars: base_image, provider, runtime_install, agent_install, langfuse (+ langfuse_install).
+    Whitespace is trimmed after this comment so the syntax directive stays the first line.
+-#}
+# syntax=docker/dockerfile:1
+FROM {{ base_image }}
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+# --- runtime ({{ provider }}) ---
+{{ runtime_install }}
+
+# --- {{ provider }} agent CLI ---
+{{ agent_install }}
+{% if langfuse %}
+# --- Langfuse tracing (side-channel: reads transcripts, fails open) ---
+{{ langfuse_install }}
+{% endif %}
+WORKDIR /testbed

--- a/src/teich/cli.py
+++ b/src/teich/cli.py
@@ -723,6 +723,11 @@ def generate(
             written = run_bench(cfg, console=console, resume=resume, refresh=refresh)
         except RuntimeError as exc:
             console.print(f"[red]{exc}[/red]")
+            # An earlier source may have harvested rows before a later one failed; write the card
+            # for that partial dataset (like prompt mode does on error). Don't auto-publish.
+            readme_path = _try_write_completed_output_metadata(cfg)
+            if readme_path:
+                console.print(f"[green]Wrote README: {readme_path}[/green]")
             raise typer.Exit(1) from exc
         if written:
             readme_path = _write_output_metadata(cfg)

--- a/src/teich/cli.py
+++ b/src/teich/cli.py
@@ -19,7 +19,7 @@ from typer.core import TyperCommand, TyperGroup
 
 from .anonymize import anonymize_path
 from .config import Config
-from .converter import convert_traces_to_training_data
+from .converter import NON_DATA_TRACE_DIR_NAMES, convert_traces_to_training_data
 from .extract import CURSOR_EXTRACTION_NOTICE, ExtractProvider, extract_local_sessions
 from .runner import (
     ChatRunner,
@@ -177,8 +177,7 @@ pool_app = typer.Typer(
     cls=_help_group("PoolHelpGroup", POOL_EXTRA_HELP),
 )
 app.add_typer(pool_app, name="pool")
-NON_DATA_TRACE_DIR_NAMES = {"partials", "failures"}
-UPLOAD_IGNORE_PATTERNS = ["partials/**", "failures/**"]
+UPLOAD_IGNORE_PATTERNS = ["partials/**", "failures/**", "bench/**"]
 UPLOAD_METADATA_PATTERNS = ["README.md", "tools.json"]
 
 
@@ -211,6 +210,25 @@ def _has_non_empty_trace_outputs(traces_dir: Path) -> bool:
     return False
 
 
+def _existing_dataset_modes(traces_dir: Path) -> set[str]:
+    """Which generation modes already wrote dataset rows into ``traces_dir``.
+
+    bench rows are ``bench-<task>.jsonl``; anything else (incl. routed
+    ``passed/``|``failed/`` traces) is prompts. Used to keep bench and prompts as
+    separate, homogeneous datasets — a mixed dir is unpleasant to consume.
+    """
+    modes: set[str] = set()
+    if not traces_dir.exists():
+        return modes
+    for path in traces_dir.rglob("*.jsonl"):
+        if not path.is_file() or path.stat().st_size == 0:
+            continue
+        if NON_DATA_TRACE_DIR_NAMES.intersection(path.relative_to(traces_dir).parts):
+            continue
+        modes.add("bench" if path.name.startswith("bench-") else "prompts")
+    return modes
+
+
 def _write_output_metadata(cfg: Config) -> Path:
     return write_traces_readme(
         cfg.output.traces_dir,
@@ -220,6 +238,9 @@ def _write_output_metadata(cfg: Config) -> Path:
         repo_id=cfg.get_publish_repo_id(),
         tools=snapshot_configured_tools(cfg),
         excluded_dirs=[cfg.output.failures_dir],
+        license=cfg.output.license,
+        card_extra=cfg.output.card_extra,
+        readme_template=cfg.output.readme_template,
     )
 
 
@@ -382,6 +403,9 @@ def _write_extract_readme(
         model_id=None,
         repo_id=cfg.get_publish_repo_id(),
         extraction_provider=provider,
+        license=cfg.output.license,
+        card_extra=cfg.output.card_extra,
+        readme_template=cfg.output.readme_template,
     )
 
 
@@ -652,8 +676,18 @@ def generate(
         "--resume",
         help="Skip prompts that already have completed answers in the output directory",
     ),
+    mode: str = typer.Option(
+        "prompts",
+        "--mode",
+        help="Generation mode: 'prompts' (default) or 'bench' (run benchmark tasks from bench.sources).",
+    ),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help="Bench mode (harbor sources only): re-download a remote harbor bench source even if it's already cached. No effect on swe-bench, which uses Hugging Face's own dataset cache.",
+    ),
 ) -> None:
-    """Generate training traces from prompts."""
+    """Generate agent traces: plain traces from prompts (--mode prompts), or reward-labeled benchmark traces from bench.sources (--mode bench)."""
     console.print(Panel.fit("Teich", style="bold blue"))
 
     if not config.exists():
@@ -665,6 +699,40 @@ def generate(
         cfg.output.traces_dir = output
     if concurrency is not None:
         cfg.max_concurrency = concurrency
+
+    if mode not in {"prompts", "bench"}:
+        console.print(f"[red]Unknown --mode '{mode}'. Use 'prompts' or 'bench'.[/red]")
+        raise typer.Exit(1)
+    conflicting_modes = _existing_dataset_modes(cfg.output.traces_dir) - {mode}
+    if conflicting_modes:
+        other = ", ".join(sorted(conflicting_modes))
+        console.print(
+            f"[red]{cfg.output.traces_dir} already contains {other}-mode data; "
+            f"refusing to mix it with {mode}-mode output.[/red]"
+        )
+        console.print(
+            "[yellow]Keep bench and prompts as separate datasets (a mixed dataset is unpleasant "
+            "to consume). Point --output at a fresh directory, or use a separate config/project "
+            "with its own output.traces_dir and publish.repo_id.[/yellow]"
+        )
+        raise typer.Exit(1)
+    if mode == "bench":
+        from .bench import run_bench  # lazy: harbor is an optional extra
+
+        try:
+            written = run_bench(cfg, console=console, resume=resume, refresh=refresh)
+        except RuntimeError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
+        if written:
+            readme_path = _write_output_metadata(cfg)
+            console.print(f"[green]Wrote README: {readme_path}[/green]")
+            if cfg.get_publish_repo_id():
+                repo_url = _publish_dataset_to_hub(cfg)
+                console.print(f"[green]Published dataset: {repo_url}[/green]")
+        else:
+            console.print("[yellow]bench: no rows written; skipping dataset card.[/yellow]")
+        return
 
     prompt_inputs = unique_prompt_inputs_by_completion_key(cfg.get_prompt_inputs())
     if not prompt_inputs:
@@ -1169,6 +1237,11 @@ output:
   # These files are excluded from resume detection, conversion, README generation, and uploads.
   failures_dir: ./failures
 
+  # Harbor bench-mode intermediates (downloaded sources, raw trials, normalized sessions).
+  # Defaults to a `bench` dir beside traces_dir (parallel to sandbox/failures), never inside
+  # the dataset. Set a path to override.
+  bench_dir: null
+
   # Used in the generated trace README.
   pretty_name: "My Agent Traces"
 
@@ -1178,6 +1251,23 @@ publish:
   repo_id: null
   hf_token: null
   private: false
+
+# Benchmark mode (`teich generate --mode bench`). Each source is run by a backend selected
+# by `type`: `harbor` (the harbor package; needs teich[harbor], Python 3.12+) or `swe-bench`
+# (the swebench package; needs teich[swe]). teich runs the configured agent on each task/
+# instance, harvests the plain native trace into output/{passed,failed,borderline}/, and
+# writes scores + provenance to output/metadata/<stem>.json. Intermediates live under
+# output.bench_dir (a sibling `bench` dir by default), outside the dataset/uploads.
+# `--resume` skips already-harvested tasks; `--refresh` re-downloads remote harbor sources
+# (no effect on swe-bench, which uses Hugging Face's own dataset cache).
+# Keep bench its own project: dedicated output.traces_dir + publish.repo_id.
+bench:
+  sources: []
+    # - { type: harbor,    source: terminal-bench@2.0 }          # registry spec
+    # - { type: harbor,    source: ./local-tasks }               # local task dir / dir of task dirs
+    # - { type: swe-bench, source: SWE-bench/SWE-bench_Verified, split: test }
+    # - { type: swe-bench, source: SWE-bench/SWE-bench_Lite, instances: [django__django-12345] }
+    #   # optional per-source: repo (git/HF registry), version, instances [..], backend (harbor)
 
 # Number of prompts to run in parallel.
 max_concurrency: 1

--- a/src/teich/cli.py
+++ b/src/teich/cli.py
@@ -1272,7 +1272,9 @@ bench:
     # - { type: harbor,    source: ./local-tasks }               # local task dir / dir of task dirs
     # - { type: swe-bench, source: SWE-bench/SWE-bench_Verified, split: test }
     # - { type: swe-bench, source: SWE-bench/SWE-bench_Lite, instances: [django__django-12345] }
-    #   # optional per-source: repo (git/HF registry), version, instances [..], backend (harbor)
+    # - { type: swe-bench, source: ./my-instances.jsonl, namespace: null }  # build custom images locally
+    #   # optional per-source: repo (git/HF registry), version, instances [..], backend (harbor);
+    #   # swe-bench namespace (default "swebench" pulls published images; null builds locally)
 
 # Number of prompts to run in parallel.
 max_concurrency: 1

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -415,8 +415,14 @@ class Config(BaseModel):
                 if not isinstance(bench_source, dict):
                     continue
                 spec = bench_source.get("source")
-                if isinstance(spec, str) and spec.strip().startswith(("./", "../", "~")):
-                    bench_source["source"] = str((path.parent / Path(spec.strip()).expanduser()).resolve())
+                if isinstance(spec, str) and spec.strip():
+                    spec_str = spec.strip()
+                    candidate = path.parent / Path(spec_str).expanduser()
+                    # Rewrite an explicit ./ ../ ~ path, or a bare relative that actually exists
+                    # beside the config (data/tasks, instances.jsonl). A registry/HF spec
+                    # (name@version, org/name) has no such local path, so it's left untouched.
+                    if spec_str.startswith(("./", "../", "~")) or candidate.exists():
+                        bench_source["source"] = str(candidate.resolve())
 
         # Apply environment variable overrides
         if model_env := _get_env_alias("TEICH_MODEL"):

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -394,6 +394,17 @@ class Config(BaseModel):
                 if not Path(prompts_file_path).is_absolute():
                     data["prompts_file"] = (path.parent / prompts_file_path).resolve()
 
+        # Resolve a relative output.readme_template against the config file, like prompts_file
+        # above — otherwise it's validated against the process CWD and `teich -c project/x.yaml`
+        # from elsewhere fails even when the template sits next to the config.
+        output_section = data.get("output")
+        if isinstance(output_section, dict):
+            template = output_section.get("readme_template")
+            if isinstance(template, str) and template.strip():
+                template_path = Path(template).expanduser()
+                if not template_path.is_absolute():
+                    output_section["readme_template"] = (path.parent / template_path).resolve()
+
         # Apply environment variable overrides
         if model_env := _get_env_alias("TEICH_MODEL"):
             data.setdefault("model", {})["model"] = model_env

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -189,8 +189,9 @@ class OutputConfig(BaseModel):
     # dir next to traces_dir, parallel to sandbox/failures (never inside the dataset).
     bench_dir: Path | None = None
     # Remove each task's per-task Docker image after the bench run (harbor's ``hb__<task>``
-    # image, the swe-bench agent layer) so they don't accumulate and fill the disk. Set True
-    # to keep them (e.g. for debugging, or to avoid rebuilds across runs).
+    # image or the pulled prebuilt task image, the swe-bench agent layer) so they don't
+    # accumulate and fill the disk. Set True to keep them (e.g. for debugging, or to avoid
+    # rebuilds/re-pulls across runs).
     keep_bench_images: bool = False
     pretty_name: str = "Agentic Training Traces"
     # Dataset-card customization (all optional; the default card is unchanged when unset).

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -405,6 +405,18 @@ class Config(BaseModel):
                 if not template_path.is_absolute():
                     output_section["readme_template"] = (path.parent / template_path).resolve()
 
+        # Resolve a relative *local* bench source (./tasks, ../x, ~/x) against the config dir, like
+        # prompts_file — otherwise it's tried against the process CWD and falls through to the
+        # remote-download path. A registry spec (name@version, org/name) never starts with those.
+        bench_section = data.get("bench")
+        if isinstance(bench_section, dict):
+            for bench_source in bench_section.get("sources") or []:
+                if not isinstance(bench_source, dict):
+                    continue
+                spec = bench_source.get("source")
+                if isinstance(spec, str) and spec.strip().startswith(("./", "../", "~")):
+                    bench_source["source"] = str((path.parent / Path(spec.strip()).expanduser()).resolve())
+
         # Apply environment variable overrides
         if model_env := _get_env_alias("TEICH_MODEL"):
             data.setdefault("model", {})["model"] = model_env

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -311,6 +311,10 @@ class BenchSource(BaseModel):
     a Hugging Face dataset id (or a local json/jsonl path). ``version``/``repo`` are harbor
     knobs; ``split``/``instances`` select swe-bench rows; ``backend`` is harbor's
     EnvironmentType. Remote data is fetched into ``<output.bench_dir>/`` and run locally.
+
+    ``namespace`` (swe-bench only) is the Docker image namespace for instance images: the
+    default ``"swebench"`` pulls the published ``swebench/...`` images; set it to ``null`` to
+    build instance images locally, which is required for custom/unpublished instances.
     """
     type: str = "harbor"
     source: str
@@ -319,6 +323,7 @@ class BenchSource(BaseModel):
     split: str | None = None
     instances: list[str] | None = None
     backend: str = "docker"
+    namespace: str | None = "swebench"
 
 
 class BenchConfig(BaseModel):

--- a/src/teich/config.py
+++ b/src/teich/config.py
@@ -185,7 +185,31 @@ class OutputConfig(BaseModel):
     traces_dir: Path = Field(default=Path("./output"))
     sandbox_dir: Path = Field(default=Path("./sandbox"))
     failures_dir: Path = Field(default=Path("./failures"))
+    # Harbor bench intermediates (trials/sources/sessions). None -> a sibling ``bench``
+    # dir next to traces_dir, parallel to sandbox/failures (never inside the dataset).
+    bench_dir: Path | None = None
+    # Remove each task's per-task Docker image after the bench run (harbor's ``hb__<task>``
+    # image, the swe-bench agent layer) so they don't accumulate and fill the disk. Set True
+    # to keep them (e.g. for debugging, or to avoid rebuilds across runs).
+    keep_bench_images: bool = False
     pretty_name: str = "Agentic Training Traces"
+    # Dataset-card customization (all optional; the default card is unchanged when unset).
+    # ``license`` adds an SPDX id to the card frontmatter; ``card_extra`` merges arbitrary
+    # extra frontmatter keys; ``readme_template`` points at a user Jinja2 template that
+    # replaces the shipped default (rendered with the same context).
+    license: str | None = None
+    card_extra: dict[str, Any] = Field(default_factory=dict)
+    readme_template: Path | None = None
+
+    @field_validator("readme_template")
+    @classmethod
+    def validate_readme_template(cls, value: Path | None) -> Path | None:
+        if value is None:
+            return None
+        path = Path(value).expanduser()
+        if not path.is_file():
+            raise ValueError(f"output.readme_template not found: {path}")
+        return path
 
 
 class PublishConfig(BaseModel):
@@ -277,6 +301,30 @@ class PromptInput(BaseModel):
         return [self.prompt, *self.follow_up_prompts]
 
 
+class BenchSource(BaseModel):
+    """One benchmark source for ``generate --mode bench``.
+
+    ``type`` selects the backend (``harbor`` | ``swe-bench``). ``source`` is the dataset
+    spec for that backend: harbor → a local task dir, a registry spec (``name@version`` or
+    ``org/name@ref``), or (with ``repo``) a dataset name in a git/HF registry; swe-bench →
+    a Hugging Face dataset id (or a local json/jsonl path). ``version``/``repo`` are harbor
+    knobs; ``split``/``instances`` select swe-bench rows; ``backend`` is harbor's
+    EnvironmentType. Remote data is fetched into ``<output.bench_dir>/`` and run locally.
+    """
+    type: str = "harbor"
+    source: str
+    repo: str | None = None
+    version: str | None = None
+    split: str | None = None
+    instances: list[str] | None = None
+    backend: str = "docker"
+
+
+class BenchConfig(BaseModel):
+    """Bench-mode settings: an array of benchmark sources, each run by its backend."""
+    sources: list[BenchSource] = Field(default_factory=list)
+
+
 class Config(BaseModel):
     """Main configuration."""
     agent: AgentConfig = Field(default_factory=AgentConfig)
@@ -287,6 +335,7 @@ class Config(BaseModel):
     prompts_file: Path | None = None
     output: OutputConfig = Field(default_factory=OutputConfig)
     publish: PublishConfig = Field(default_factory=PublishConfig)
+    bench: BenchConfig = Field(default_factory=BenchConfig)
     max_concurrency: int = Field(default=1, ge=1)
     timeout_seconds: int = 600
     openai_api_key: str | None = None

--- a/src/teich/converter.py
+++ b/src/teich/converter.py
@@ -18,6 +18,15 @@ from .tool_schema import (
 )
 
 _INLINE_THINKING_BLOCK_PATTERN = re.compile(r"<(think|thinking)>(.*?)</\1>", re.DOTALL)
+# Output subdirectories that hold non-dataset artifacts (partial/failed runs, verifier
+# sidecars, sandbox checkouts, harbor bench intermediates). Dataset scanners, the README
+# builder, and the mode guard skip these so the dataset view stays clean. (Publish keeps
+# its own UPLOAD_IGNORE_PATTERNS in cli.py, which drops partials/failures/bench but still
+# uploads verifier sidecars as dataset provenance.) The bench intermediates normally live
+# in a sibling ``bench`` dir; the name is listed here only to defend a nested override.
+NON_DATA_TRACE_DIR_NAMES = frozenset(
+    {"partials", "failures", "verification", "sandbox", "__pycache__", "bench"}
+)
 FIRST_MESSAGE_TIMESTAMP_METADATA_KEY = "first_message_timestamp"
 PI_SYSTEM_PROMPT_CUSTOM_TYPE = "teich-system-prompt"
 TEICH_AVAILABLE_TOOLS_CUSTOM_TYPE = "teich-available-tools"
@@ -3933,7 +3942,8 @@ def _jsonl_files(source: Path) -> list[Path]:
     return sorted(
         path
         for path in source.rglob("*.jsonl")
-        if path.is_file() and not {"partials", "failures"}.intersection(path.relative_to(source).parts)
+        if path.is_file()
+        and not NON_DATA_TRACE_DIR_NAMES.intersection(path.relative_to(source).parts)
     )
 
 
@@ -3979,5 +3989,6 @@ def convert_traces_to_training_data(traces_dir: Path | str, *, skip_invalid_line
     trace_files = _jsonl_files(source)
     rows: list[dict[str, Any]] = []
     for path in trace_files:
-        rows.extend(_convert_jsonl_file_to_training_rows(path, skip_invalid_lines=skip_invalid_lines))
+        file_rows = _convert_jsonl_file_to_training_rows(path, skip_invalid_lines=skip_invalid_lines)
+        rows.extend(file_rows)
     return rows

--- a/src/teich/runner.py
+++ b/src/teich/runner.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .config import Config
 
+from . import agent_cfg
 from .config import PromptInput
 
 from .codex_auth_broker import CodexTokenBroker
@@ -1045,14 +1046,7 @@ class DockerRuntimeRunner:
 
     @staticmethod
     def _container_base_url(base_url: str | None) -> str | None:
-        if not base_url:
-            return None
-        parsed = urlsplit(base_url)
-        hostname = parsed.hostname or ""
-        if hostname not in {"localhost", "127.0.0.1"}:
-            return base_url
-        netloc = parsed.netloc.replace(hostname, "host.docker.internal", 1)
-        return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+        return agent_cfg.container_base_url(base_url)
 
     def _langfuse_container_base_url(self) -> str | None:
         return self._container_base_url(self.config.agent.langfuse.base_url)
@@ -2864,26 +2858,7 @@ class ExternalCliRunner(DockerRuntimeRunner):
 
     @staticmethod
     def _provider_env_key(provider: str) -> str:
-        normalized = re.sub(r"[^a-zA-Z0-9_]+", "_", provider.strip().lower())
-        aliases = {
-            "anthropic": "ANTHROPIC_API_KEY",
-            "claude": "ANTHROPIC_API_KEY",
-            "claude_code": "ANTHROPIC_API_KEY",
-            "claude-code": "ANTHROPIC_API_KEY",
-            "openai": "OPENAI_API_KEY",
-            "openrouter": "OPENROUTER_API_KEY",
-            "nous": "NOUS_API_KEY",
-            "nous_portal": "NOUS_API_KEY",
-            "google": "GOOGLE_API_KEY",
-            "gemini": "GEMINI_API_KEY",
-            "deepseek": "DEEPSEEK_API_KEY",
-            "xai": "XAI_API_KEY",
-            "grok": "XAI_API_KEY",
-            "zai": "GLM_API_KEY",
-            "z_ai": "GLM_API_KEY",
-            "glm": "GLM_API_KEY",
-        }
-        return aliases.get(normalized, f"{normalized.upper() or 'TEICH'}_API_KEY")
+        return agent_cfg.provider_env_key(provider)
 
     def _api_env_items(self) -> list[tuple[str, str]]:
         api_key = self.config.get_api_key() or ""

--- a/src/teich/runner.py
+++ b/src/teich/runner.py
@@ -32,6 +32,7 @@ from .config import PromptInput
 from .codex_auth_broker import CodexTokenBroker
 
 from .converter import (
+    NON_DATA_TRACE_DIR_NAMES,
     TEICH_AVAILABLE_TOOLS_CUSTOM_TYPE,
     convert_trace_to_training_example,
     convert_traces_to_training_data,
@@ -69,7 +70,6 @@ HERMES_DEFAULT_TOOLSETS = "safe,terminal,file,skills,memory,session_search,deleg
 HERMES_TRACE_WRITE_LOCK = threading.Lock()
 CHAT_REQUEST_MAX_ATTEMPTS = 3
 AGENT_TURN_RETRY_LIMIT = 3
-NON_DATA_TRACE_DIR_NAMES = {"partials", "failures"}
 
 
 def _make_tree_world_writable(path: Path) -> None:

--- a/src/teich/studio/extraction.py
+++ b/src/teich/studio/extraction.py
@@ -173,6 +173,9 @@ class ExtractionJob:
             model_id=None,
             repo_id=cfg.get_publish_repo_id(),
             extraction_provider=self.provider,
+            license=cfg.output.license,
+            card_extra=cfg.output.card_extra,
+            readme_template=cfg.output.readme_template,
         )
         self.events.append({"kind": "extract_readme", "text": f"Wrote {readme_path.name}.", "path": str(readme_path)})
 

--- a/src/teich/studio/generation.py
+++ b/src/teich/studio/generation.py
@@ -185,6 +185,9 @@ class GenerationJob:
                 repo_id=self.config.get_publish_repo_id(),
                 tools=snapshot_configured_tools(self.config),
                 excluded_dirs=[self.config.output.failures_dir],
+                license=self.config.output.license,
+                card_extra=self.config.output.card_extra,
+                readme_template=self.config.output.readme_template,
             )
         except Exception:
             pass

--- a/src/teich/studio/server.py
+++ b/src/teich/studio/server.py
@@ -844,6 +844,9 @@ def create_app(project_dir: Path) -> FastAPI:
                 repo_id=publish.repo_id,
                 extraction_provider=extraction_provider,
                 excluded_dirs=[cfg.output.failures_dir],
+                license=cfg.output.license,
+                card_extra=cfg.output.card_extra,
+                readme_template=cfg.output.readme_template,
             )
             repo_url = _upload_dataset_folder(
                 folder_path=cfg.output.traces_dir,

--- a/src/teich/templates/dataset_card.md.j2
+++ b/src/teich/templates/dataset_card.md.j2
@@ -46,7 +46,7 @@ This is a verifiable dataset: rows carry the task verifier's outcome so it can b
 - `passed` (bool): whether the task verifier succeeded after the agent's edits
 - `reward` (float): the verifier's own score when it reports one, else the binary `1.0`/`0.0` implied by `passed`
 
-Verified tasks: {{ reward_stats.total }} ({{ reward_stats.passed }} passed / {{ reward_stats.failed }} failed).
+Verified tasks: {{ reward_stats.total }} ({{ reward_stats.passed }} passed / {{ reward_stats.failed }} failed{% if reward_stats.borderline %} / {{ reward_stats.borderline }} borderline{% endif %}).
 Each reward comes from the task verifier run after the agent's attempt.
 {% if reward_stats.numeric %}
 {{ reward_stats.numeric }} of {{ reward_stats.total }} carry an explicit numeric score (the rest are binary pass/fail).

--- a/src/teich/templates/dataset_card.md.j2
+++ b/src/teich/templates/dataset_card.md.j2
@@ -1,0 +1,140 @@
+---
+pretty_name: "{{ pretty_name }}"
+task_categories:
+- text-generation
+{% if tags %}
+tags:
+{% for tag in tags %}
+- "{{ tag }}"
+{% endfor %}
+{% endif %}
+configs:
+- config_name: default
+  data_files:
+{% for split, path in data_files %}
+  - split: {{ split }}
+    path: "{{ path }}"
+{% endfor %}
+{% if license %}
+license: {{ license }}
+{% endif %}
+{% if size_categories %}
+size_categories:
+{% for size in size_categories %}
+- {{ size }}
+{% endfor %}
+{% endif %}
+{{ card_extra_yaml }}---
+
+This dataset was generated using [teich](https://github.com/TeichAI/teich) by [TeichAI](https://huggingface.co/TeichAI) <img src="https://cdn-avatars.huggingface.co/v1/production/uploads/6837935ac3b7ffe0d2559ce9/-AxyvV4wfUY8uo87kNKkK.png" width="20" height="20" style="display: inline-block; vertical-align: middle; margin: 0 3px;">
+
+# {{ pretty_name }}
+
+{{ intro_line }}
+
+{{ rows_line }}
+
+{% if model_id %}
+Model metadata: `{{ model_id }}`
+
+{% endif %}
+{% if reward_stats %}
+## Reward labels
+
+This is a verifiable dataset: rows carry the task verifier's outcome so it can be used for reward-based training and filtering.
+
+- `passed` (bool): whether the task verifier succeeded after the agent's edits
+- `reward` (float): the verifier's own score when it reports one, else the binary `1.0`/`0.0` implied by `passed`
+
+Verified tasks: {{ reward_stats.total }} ({{ reward_stats.passed }} passed / {{ reward_stats.failed }} failed).
+Each reward comes from the task verifier run after the agent's attempt.
+{% if reward_stats.numeric %}
+{{ reward_stats.numeric }} of {{ reward_stats.total }} carry an explicit numeric score (the rest are binary pass/fail).
+{% endif %}
+
+{% endif %}
+{% if dataset_tools %}
+## Training-ready tools
+
+Generated agent traces carry configured or recovered tool schemas so tools remain available for training even when a session did not call them.
+Native Claude Code imports recover schemas for Claude Code and Claude Desktop built-ins, plus conservative name-derived MCP schemas, when the raw transcript only records tool names or calls.
+{% if externalize_tools %}
+A complete dataset-level `tools` schema snapshot is stored in `tools.json` to keep this dataset card upload-safe.
+{% else %}
+A complete dataset-level `tools` schema snapshot is embedded in the collapsed section at the bottom of this README.
+{% endif %}
+`load_traces` applies the dataset snapshot to each loaded example as a fallback `tools` field.
+
+{% endif %}
+{% if extraction_provider %}
+## Create A Similar Dataset
+
+This dataset was staged from existing local agent sessions with `teich extract`.
+To build your own local dataset, install Teich and point it at one of the supported providers:
+
+```bash
+teich extract {{ extraction_provider }} --out data
+```
+
+Use `--sessions-dir /path/to/store` when your sessions are not in the default location,
+and `--model <substring>` when you only want sessions whose model metadata matches a value.
+
+{% endif %}
+## Format
+
+{% if structured_dataset %}
+Each file is newline-delimited JSON where every line is already a training example.
+Chat-only datasets include `messages` plus convenience fields like optional `system`, `prompt`, `follow_up_prompts`, `thinking`, `response`, and `responses`.
+Tool datasets can include the same normalized `messages` structure together with a `tools` field.
+
+{% elif agent_trace_rows %}
+Each file is newline-delimited JSON where every line is one preserved agent session.
+Rows use `id`, `task`, `traces`, `tools`, and `metadata`:
+
+- `id`: provider session id
+- `task`: first user prompt extracted from the trace
+- `traces`: native conversation messages in `from` / `value` form
+- `tools`: the tool schema available to that session, including tools that were not called
+- `metadata`: provider, model, first-message timestamp, token, cost, parent-session, and export details
+- `metadata.first_message_timestamp`: first timestamp-bearing source user message when the trace format provides one
+
+{% else %}
+Each file is newline-delimited JSON representing a single captured agent session.
+The trace schema is designed for upload-first preservation so you can keep the original session history and convert it later for training.
+Teich normalizes split assistant fragments during trace copy and conversion so the semantic order is reasoning first, optional assistant text second, and tool calls last.
+Native Claude Code conversion also preserves runtime context such as skills, MCP instructions, hook context, permission state, date changes, and session recaps as masked `system` messages when the raw transcript provides them.
+
+Common top-level event groups:
+
+- `session_meta`
+- `turn_context`
+- `event_msg`
+- `response_item`
+- `session`
+- `message`
+- `session_info`
+- `model_change`
+- `thinking_level_change`
+- `external_session_meta`
+- `external_message`
+- `external_stderr`
+
+{% endif %}
+{% if sample_block %}
+## Example
+
+```json
+{{ sample_block }}
+```
+
+{% endif %}
+## Training
+
+Use this dataset as `{{ dataset_reference }}` with Teich's data preparation and training utilities.
+If you do not want Teich to handle chat-template formatting or masking, run `teich convert` to write standalone OpenAI-style JSONL rows with `prompt`, `messages`, `tools`, and `metadata`.
+Training setup details evolve over time, so the maintained guide lives in the [Teich training docs]({{ training_docs_url }}).
+For loading, mixing, converting, and validating Teich datasets, see [Preparing Data]({{ prepare_docs_url }}).
+{% if dataset_tools %}
+
+{{ tools_details_block }}
+{% endif %}

--- a/src/teich/trace_readme.py
+++ b/src/teich/trace_readme.py
@@ -215,7 +215,7 @@ def _dataset_tools(trace_files: Iterable[Path]) -> list[dict[str, Any]]:
     return [merged_by_name[name] for name in sorted(merged_by_name)]
 
 
-def _split_data_files(traces_dir: Path) -> list[tuple[str, str]]:
+def _split_data_files(traces_dir: Path, excluded_dirs: Iterable[Path] = ()) -> list[tuple[str, str]]:
     """Dataset-card split -> file glob, reflecting the actual routing folders.
 
     When routed split folders (passed/failed/borderline) hold data, expose them as
@@ -225,6 +225,10 @@ def _split_data_files(traces_dir: Path) -> list[tuple[str, str]]:
     (e.g. Cursor's project-relative transcripts) live only in subdirs, so a bare
     top-level ``*.jsonl`` would advertise an empty dataset while the card still counts
     those rows — HF's ``data_files`` config must reach them.
+
+    ``excluded_dirs`` (e.g. a custom ``output.failures_dir`` under ``traces_dir``) are
+    skipped too — they hold ignored/failed runs and their basename may not be in the
+    reserved non-data set, so they must not be advertised as a train split.
     """
     routing = ("passed", "failed", "borderline")
     splits = [
@@ -234,10 +238,18 @@ def _split_data_files(traces_dir: Path) -> list[tuple[str, str]]:
     ]
     if splits:
         return splits
+    traces_resolved = traces_dir.resolve()
+    excluded_names = {
+        excluded.resolve().relative_to(traces_resolved).parts[0]
+        for excluded in excluded_dirs
+        if excluded.resolve() != traces_resolved and _path_is_relative_to(excluded, traces_dir)
+    }
     patterns = ["*.jsonl"]
     if traces_dir.is_dir():
         for child in sorted(traces_dir.iterdir()):
             if not child.is_dir() or child.name in NON_DATA_TRACE_DIR_NAMES or child.name in routing:
+                continue
+            if child.name in excluded_names:
                 continue
             if any(child.rglob("*.jsonl")):
                 patterns.append(f"{child.name}/**/*.jsonl")
@@ -606,7 +618,7 @@ def write_traces_readme(
             tools=dataset_tools,
             extraction_provider=extraction_provider,
             reward_stats=_reward_stats(traces_dir, trace_files),
-            data_files=_split_data_files(traces_dir),
+            data_files=_split_data_files(traces_dir, excluded_dirs or []),
             license=license,
             card_extra=card_extra,
             readme_template=readme_template,

--- a/src/teich/trace_readme.py
+++ b/src/teich/trace_readme.py
@@ -419,7 +419,7 @@ def _reward_stats(traces_dir: Path, trace_files: Iterable[Path]) -> dict[str, in
     """
     live_stems = {path.stem for path in trace_files}
     counted: set[str] = set()
-    passed = failed = numeric = 0
+    passed = failed = borderline = numeric = 0
 
     def _numeric(reward: Any) -> bool:
         return isinstance(reward, (int, float)) and not isinstance(reward, bool)
@@ -456,14 +456,17 @@ def _reward_stats(traces_dir: Path, trace_files: Iterable[Path]) -> dict[str, in
                 passed += 1
             elif split == "failed":
                 failed += 1
+            elif split == "borderline":
+                borderline += 1  # a partial score (0<r<1): verified, but neither pass nor fail
             else:
-                continue  # borderline / unknown: verified but neither pass nor fail
+                continue  # unknown split: not a verified outcome
             counted.add(sidecar.stem)
             numeric += 1 if _numeric(data.get("reward")) else 0
 
-    if passed + failed == 0:
+    total = passed + failed + borderline
+    if total == 0:
         return None
-    return {"total": passed + failed, "passed": passed, "failed": failed, "numeric": numeric}
+    return {"total": total, "passed": passed, "failed": failed, "borderline": borderline, "numeric": numeric}
 
 
 def _sanitize_card_extra(card_extra: dict[str, Any] | None) -> dict[str, Any]:

--- a/src/teich/trace_readme.py
+++ b/src/teich/trace_readme.py
@@ -219,16 +219,29 @@ def _split_data_files(traces_dir: Path) -> list[tuple[str, str]]:
     """Dataset-card split -> file glob, reflecting the actual routing folders.
 
     When routed split folders (passed/failed/borderline) hold data, expose them as
-    HF splits; otherwise a single ``train`` split over the top-level files only —
-    ``*.jsonl`` (not ``**/*.jsonl``), so the non-data subdirs the body excludes
-    (partials/failures/bench/verification) are never advertised in the card.
+    HF splits. Otherwise a single ``train`` split: the top-level ``*.jsonl`` files
+    plus a recursive ``<dir>/**/*.jsonl`` for each data-bearing subdir that isn't a
+    known non-data dir (partials/failures/bench/verification/...). Nested extractions
+    (e.g. Cursor's project-relative transcripts) live only in subdirs, so a bare
+    top-level ``*.jsonl`` would advertise an empty dataset while the card still counts
+    those rows — HF's ``data_files`` config must reach them.
     """
+    routing = ("passed", "failed", "borderline")
     splits = [
         (name, f"{name}/*.jsonl")
-        for name in ("passed", "failed", "borderline")
+        for name in routing
         if (traces_dir / name).is_dir() and any((traces_dir / name).glob("*.jsonl"))
     ]
-    return splits or [("train", "*.jsonl")]
+    if splits:
+        return splits
+    patterns = ["*.jsonl"]
+    if traces_dir.is_dir():
+        for child in sorted(traces_dir.iterdir()):
+            if not child.is_dir() or child.name in NON_DATA_TRACE_DIR_NAMES or child.name in routing:
+                continue
+            if any(child.rglob("*.jsonl")):
+                patterns.append(f"{child.name}/**/*.jsonl")
+    return [("train", pattern) for pattern in patterns]
 
 
 def _truncate_text(value: str, max_chars: int) -> str:
@@ -394,35 +407,60 @@ def _tools_details_block(tools: list[dict[str, Any]]) -> list[str]:
 
 
 def _reward_stats(traces_dir: Path, trace_files: Iterable[Path]) -> dict[str, int] | None:
-    """Summarize verifier outcomes from the canonical ``verification/`` sidecars.
+    """Summarize verifier outcomes for the dataset card.
 
-    Both reward-labeled paths write a ``verification/<stem>.json`` with a ``passed``
-    bool (bench also writes a numeric ``reward``), so one scan describes a dataset
-    that is all-prompts, all-bench, or a mix. Only sidecars whose stem matches a live
-    dataset row are counted, so a stale/orphaned sidecar can't inflate the count.
+    Two reward-labeled paths write sidecars in different shapes: the prompt-mode seed
+    verifier writes ``verification/<stem>.json`` with a ``passed`` bool, while bench
+    harvest writes ``metadata/<stem>.json`` with a ``split`` (passed/failed/borderline)
+    and a numeric ``reward``. Scan both so the counts describe an all-prompts, all-bench,
+    or mixed dataset. Only sidecars whose stem matches a live dataset row are counted (so
+    a stale/orphaned sidecar can't inflate the count), and each stem is counted once.
     Returns None when nothing is verified.
     """
-    verification_dir = traces_dir / "verification"
-    if not verification_dir.is_dir():
-        return None
     live_stems = {path.stem for path in trace_files}
+    counted: set[str] = set()
     passed = failed = numeric = 0
-    for sidecar in sorted(verification_dir.glob("*.json")):
-        if sidecar.stem not in live_stems:
-            continue
-        try:
-            data = json.loads(sidecar.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(data, dict) or not isinstance(data.get("passed"), bool):
-            continue
-        if data["passed"]:
-            passed += 1
-        else:
-            failed += 1
-        reward = data.get("reward")
-        if isinstance(reward, (int, float)) and not isinstance(reward, bool):
-            numeric += 1
+
+    def _numeric(reward: Any) -> bool:
+        return isinstance(reward, (int, float)) and not isinstance(reward, bool)
+
+    verification_dir = traces_dir / "verification"
+    if verification_dir.is_dir():
+        for sidecar in sorted(verification_dir.glob("*.json")):
+            if sidecar.stem not in live_stems or sidecar.stem in counted:
+                continue
+            try:
+                data = json.loads(sidecar.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict) or not isinstance(data.get("passed"), bool):
+                continue
+            counted.add(sidecar.stem)
+            passed += 1 if data["passed"] else 0
+            failed += 0 if data["passed"] else 1
+            numeric += 1 if _numeric(data.get("reward")) else 0
+
+    metadata_dir = traces_dir / "metadata"
+    if metadata_dir.is_dir():
+        for sidecar in sorted(metadata_dir.glob("*.json")):
+            if sidecar.stem not in live_stems or sidecar.stem in counted:
+                continue
+            try:
+                data = json.loads(sidecar.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            split = data.get("split")
+            if split == "passed":
+                passed += 1
+            elif split == "failed":
+                failed += 1
+            else:
+                continue  # borderline / unknown: verified but neither pass nor fail
+            counted.add(sidecar.stem)
+            numeric += 1 if _numeric(data.get("reward")) else 0
+
     if passed + failed == 0:
         return None
     return {"total": passed + failed, "passed": passed, "failed": failed, "numeric": numeric}

--- a/src/teich/trace_readme.py
+++ b/src/teich/trace_readme.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Any, Iterable
 
-from .converter import convert_traces_to_training_data
+from .converter import NON_DATA_TRACE_DIR_NAMES, convert_traces_to_training_data
 
 README_SAMPLE_MAX_CHARS = 4_000
 README_SAMPLE_STRING_MAX_CHARS = 600
@@ -15,7 +15,40 @@ README_INLINE_TOOLS_MAX_CHARS = 80_000
 TEICH_TRAINING_DOCS_URL = "https://github.com/TeichAI/teich/blob/main/docs/training.md"
 TEICH_PREPARE_DOCS_URL = "https://github.com/TeichAI/teich/blob/main/docs/prepare-data.md"
 EXTRACTION_PROVIDERS = {"claude", "codex", "cursor", "hermes", "pi"}
-NON_DATA_README_SCAN_DIR_NAMES = {"failures", "partials", "sandbox", "__pycache__"}
+
+_TEMPLATE_DIR = Path(__file__).parent / "templates"
+_DEFAULT_CARD_TEMPLATE = "dataset_card.md.j2"
+# Frontmatter keys the card owns; a user's ``card_extra`` may not shadow them.
+_RESERVED_CARD_KEYS = frozenset(
+    {"pretty_name", "task_categories", "tags", "configs", "size_categories", "license"}
+)
+# Hugging Face dataset-card ``size_categories`` buckets, ascending by upper bound.
+_SIZE_BUCKETS: tuple[tuple[int, str], ...] = (
+    (1_000, "n<1K"),
+    (10_000, "1K<n<10K"),
+    (100_000, "10K<n<100K"),
+    (1_000_000, "100K<n<1M"),
+    (10_000_000, "1M<n<10M"),
+    (100_000_000, "10M<n<100M"),
+    (1_000_000_000, "100M<n<1B"),
+    (10_000_000_000, "1B<n<10B"),
+    (100_000_000_000, "10B<n<100B"),
+    (1_000_000_000_000, "100B<n<1T"),
+)
+
+
+def size_category(row_count: int) -> str | None:
+    """Map a dataset row count to its Hugging Face ``size_categories`` bucket.
+
+    Returns ``None`` for an empty/unknown dataset (``row_count <= 0``) so the card
+    omits the key rather than advertising a bogus size.
+    """
+    if row_count <= 0:
+        return None
+    for upper, label in _SIZE_BUCKETS:
+        if row_count < upper:
+            return label
+    return "n>1T"
 
 
 def normalize_extraction_provider(provider: str | None) -> str | None:
@@ -61,7 +94,7 @@ def extraction_provider_from_dataset_rows(traces_dir: Path) -> str | None:
             relative_parts = trace_file.relative_to(traces_dir).parts
         except ValueError:
             relative_parts = trace_file.parts
-        if any(part in NON_DATA_README_SCAN_DIR_NAMES for part in relative_parts):
+        if any(part in NON_DATA_TRACE_DIR_NAMES for part in relative_parts):
             continue
         try:
             with trace_file.open("r", encoding="utf-8") as handle:
@@ -182,29 +215,20 @@ def _dataset_tools(trace_files: Iterable[Path]) -> list[dict[str, Any]]:
     return [merged_by_name[name] for name in sorted(merged_by_name)]
 
 
-def _frontmatter(pretty_name: str, tags: list[str]) -> str:
-    lines = [
-        "---",
-        f'pretty_name: "{pretty_name}"',
-        "task_categories:",
-        "- text-generation",
+def _split_data_files(traces_dir: Path) -> list[tuple[str, str]]:
+    """Dataset-card split -> file glob, reflecting the actual routing folders.
+
+    When routed split folders (passed/failed/borderline) hold data, expose them as
+    HF splits; otherwise a single ``train`` split over the top-level files only —
+    ``*.jsonl`` (not ``**/*.jsonl``), so the non-data subdirs the body excludes
+    (partials/failures/bench/verification) are never advertised in the card.
+    """
+    splits = [
+        (name, f"{name}/*.jsonl")
+        for name in ("passed", "failed", "borderline")
+        if (traces_dir / name).is_dir() and any((traces_dir / name).glob("*.jsonl"))
     ]
-    if tags:
-        lines.append("tags:")
-        for tag in tags:
-            lines.append(f'- "{tag}"')
-    lines.extend(
-        [
-            "configs:",
-            "- config_name: default",
-            "  data_files:",
-            "  - split: train",
-            '    path: "**/*.jsonl"',
-            "---",
-            "",
-        ]
-    )
-    return "\n".join(lines)
+    return splits or [("train", "*.jsonl")]
 
 
 def _truncate_text(value: str, max_chars: int) -> str:
@@ -369,22 +393,77 @@ def _tools_details_block(tools: list[dict[str, Any]]) -> list[str]:
     ]
 
 
-def _extraction_snippet(provider: str) -> list[str]:
-    provider = normalize_extraction_provider(provider) or provider.strip().lower().replace("_", "-") or "claude"
-    return [
-        "## Create A Similar Dataset",
-        "",
-        "This dataset was staged from existing local agent sessions with `teich extract`.",
-        "To build your own local dataset, install Teich and point it at one of the supported providers:",
-        "",
-        "```bash",
-        f"teich extract {provider} --out data",
-        "```",
-        "",
-        "Use `--sessions-dir /path/to/store` when your sessions are not in the default location,",
-        "and `--model <substring>` when you only want sessions whose model metadata matches a value.",
-        "",
-    ]
+def _reward_stats(traces_dir: Path, trace_files: Iterable[Path]) -> dict[str, int] | None:
+    """Summarize verifier outcomes from the canonical ``verification/`` sidecars.
+
+    Both reward-labeled paths write a ``verification/<stem>.json`` with a ``passed``
+    bool (bench also writes a numeric ``reward``), so one scan describes a dataset
+    that is all-prompts, all-bench, or a mix. Only sidecars whose stem matches a live
+    dataset row are counted, so a stale/orphaned sidecar can't inflate the count.
+    Returns None when nothing is verified.
+    """
+    verification_dir = traces_dir / "verification"
+    if not verification_dir.is_dir():
+        return None
+    live_stems = {path.stem for path in trace_files}
+    passed = failed = numeric = 0
+    for sidecar in sorted(verification_dir.glob("*.json")):
+        if sidecar.stem not in live_stems:
+            continue
+        try:
+            data = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict) or not isinstance(data.get("passed"), bool):
+            continue
+        if data["passed"]:
+            passed += 1
+        else:
+            failed += 1
+        reward = data.get("reward")
+        if isinstance(reward, (int, float)) and not isinstance(reward, bool):
+            numeric += 1
+    if passed + failed == 0:
+        return None
+    return {"total": passed + failed, "passed": passed, "failed": failed, "numeric": numeric}
+
+
+def _sanitize_card_extra(card_extra: dict[str, Any] | None) -> dict[str, Any]:
+    """Drop reserved frontmatter keys the card owns; keep user keys in order."""
+    if not card_extra:
+        return {}
+    return {key: value for key, value in card_extra.items() if key not in _RESERVED_CARD_KEYS}
+
+
+def _card_extra_yaml(card_extra: dict[str, Any] | None) -> str:
+    """Serialize ``card_extra`` to YAML frontmatter lines (empty dict -> "")."""
+    sanitized = _sanitize_card_extra(card_extra)
+    if not sanitized:
+        return ""
+    import yaml
+
+    return yaml.safe_dump(sanitized, sort_keys=False, default_flow_style=False)
+
+
+def _render_card(context: dict[str, Any], template_path: Path | None = None) -> str:
+    """Render the dataset card from ``context`` via Jinja2 (default or user template)."""
+    from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+    if template_path is not None:
+        loader_dir = str(template_path.parent)
+        template_name = template_path.name
+    else:
+        loader_dir = str(_TEMPLATE_DIR)
+        template_name = _DEFAULT_CARD_TEMPLATE
+    env = Environment(
+        loader=FileSystemLoader(loader_dir),
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
+    template = env.get_template(template_name)
+    return template.render(**context)
 
 
 def build_traces_readme(
@@ -396,6 +475,11 @@ def build_traces_readme(
     repo_id: str | None = None,
     tools: list[dict[str, Any]] | None = None,
     extraction_provider: str | None = None,
+    reward_stats: dict[str, int] | None = None,
+    data_files: list[tuple[str, str]] | None = None,
+    license: str | None = None,
+    card_extra: dict[str, Any] | None = None,
+    readme_template: Path | None = None,
 ) -> str:
     structured_dataset = _is_structured_dataset(trace_files)
     agent_trace_rows = _is_agent_trace_row_dataset(trace_files)
@@ -404,113 +488,48 @@ def build_traces_readme(
     row_count = _row_count(trace_files)
     sample_lines = _sample_lines(trace_files)
     sample_block = "\n".join(sample_lines)
-    lines = [
-        _frontmatter(pretty_name, tags),
-        'This dataset was generated using [teich](https://github.com/TeichAI/teich) by [TeichAI](https://huggingface.co/TeichAI) <img src="https://cdn-avatars.huggingface.co/v1/production/uploads/6837935ac3b7ffe0d2559ce9/-AxyvV4wfUY8uo87kNKkK.png" width="20" height="20" style="display: inline-block; vertical-align: middle; margin: 0 3px;">',
-        "",
-        f"# {pretty_name}",
-        "",
-        (
+    effective_tags = list(tags)
+    routed = any(split != "train" for split, _ in data_files or [])
+    if (reward_stats or routed) and "reward-labeled" not in effective_tags:
+        effective_tags.append("reward-labeled")
+    normalized_provider = (
+        normalize_extraction_provider(extraction_provider)
+        or extraction_provider.strip().lower().replace("_", "-")
+        or "claude"
+        if extraction_provider
+        else None
+    )
+    size = size_category(row_count)
+    is_row_dataset = structured_dataset or agent_trace_rows
+    context: dict[str, Any] = {
+        "pretty_name": pretty_name,
+        "tags": effective_tags,
+        "data_files": list(data_files or [("train", "**/*.jsonl")]),
+        "license": license,
+        "size_categories": [size] if size else None,
+        "card_extra_yaml": _card_extra_yaml(card_extra),
+        "model_id": model_id,
+        "reward_stats": reward_stats,
+        "dataset_tools": dataset_tools,
+        "externalize_tools": _should_externalize_tools(dataset_tools),
+        "tools_details_block": "\n".join(_tools_details_block(dataset_tools)).rstrip("\n")
+        if dataset_tools
+        else "",
+        "extraction_provider": normalized_provider,
+        "structured_dataset": structured_dataset,
+        "agent_trace_rows": agent_trace_rows,
+        "sample_block": sample_block,
+        "dataset_reference": dataset_reference,
+        "training_docs_url": TEICH_TRAINING_DOCS_URL,
+        "prepare_docs_url": TEICH_PREPARE_DOCS_URL,
+        "intro_line": (
             "This directory contains newline-delimited JSON training examples generated by teich."
             if structured_dataset
             else "This directory contains raw agent trace files generated by teich."
         ),
-        "",
-        f"Rows: {row_count}" if structured_dataset or agent_trace_rows else f"JSONL files: {len(trace_files)}",
-        "",
-    ]
-    if model_id:
-        lines.extend([f"Model metadata: `{model_id}`", ""])
-    if dataset_tools:
-        lines.extend(
-            [
-                "## Training-ready tools",
-                "",
-                "Generated agent traces carry configured or recovered tool schemas so tools remain available for training even when a session did not call them.",
-                "Native Claude Code imports recover schemas for Claude Code and Claude Desktop built-ins, plus conservative name-derived MCP schemas, when the raw transcript only records tool names or calls.",
-                (
-                    "A complete dataset-level `tools` schema snapshot is embedded in the collapsed section at the bottom of this README."
-                    if not _should_externalize_tools(dataset_tools)
-                    else "A complete dataset-level `tools` schema snapshot is stored in `tools.json` to keep this dataset card upload-safe."
-                ),
-                "`load_traces` applies the dataset snapshot to each loaded example as a fallback `tools` field.",
-                "",
-            ]
-        )
-    if extraction_provider:
-        lines.extend(_extraction_snippet(extraction_provider))
-    lines.extend(
-        [
-            "## Format",
-            "",
-        ]
-    )
-    if structured_dataset:
-        lines.extend(
-            [
-                "Each file is newline-delimited JSON where every line is already a training example.",
-                "Chat-only datasets include `messages` plus convenience fields like optional `system`, `prompt`, `follow_up_prompts`, `thinking`, `response`, and `responses`.",
-                "Tool datasets can include the same normalized `messages` structure together with a `tools` field.",
-                "",
-            ]
-        )
-    elif agent_trace_rows:
-        lines.extend(
-            [
-                "Each file is newline-delimited JSON where every line is one preserved agent session.",
-                "Rows use `id`, `task`, `traces`, `tools`, and `metadata`:",
-                "",
-                "- `id`: provider session id",
-                "- `task`: first user prompt extracted from the trace",
-                "- `traces`: native conversation messages in `from` / `value` form",
-                "- `tools`: the tool schema available to that session, including tools that were not called",
-                "- `metadata`: provider, model, first-message timestamp, token, cost, parent-session, and export details",
-                "- `metadata.first_message_timestamp`: first timestamp-bearing source user message when the trace format provides one",
-                "",
-            ]
-        )
-    else:
-        lines.extend(
-            [
-                "Each file is newline-delimited JSON representing a single captured agent session.",
-                "The trace schema is designed for upload-first preservation so you can keep the original session history and convert it later for training.",
-                "Teich normalizes split assistant fragments during trace copy and conversion so the semantic order is reasoning first, optional assistant text second, and tool calls last.",
-                "Native Claude Code conversion also preserves runtime context such as skills, MCP instructions, hook context, permission state, date changes, and session recaps as masked `system` messages when the raw transcript provides them.",
-                "",
-                "Common top-level event groups:",
-                "",
-                "- `session_meta`",
-                "- `turn_context`",
-                "- `event_msg`",
-                "- `response_item`",
-                "- `session`",
-                "- `message`",
-                "- `session_info`",
-                "- `model_change`",
-                "- `thinking_level_change`",
-                "- `external_session_meta`",
-                "- `external_message`",
-                "- `external_stderr`",
-                "",
-            ]
-        )
-    if sample_block:
-        lines.extend(["## Example", "", "```json", sample_block, "```", ""])
-    lines.extend(
-        [
-            "## Training",
-            "",
-            f"Use this dataset as `{dataset_reference}` with Teich's data preparation and training utilities.",
-            "If you do not want Teich to handle chat-template formatting or masking, run `teich convert` "
-            "to write standalone OpenAI-style JSONL rows with `prompt`, `messages`, `tools`, and `metadata`.",
-            f"Training setup details evolve over time, so the maintained guide lives in the [Teich training docs]({TEICH_TRAINING_DOCS_URL}).",
-            f"For loading, mixing, converting, and validating Teich datasets, see [Preparing Data]({TEICH_PREPARE_DOCS_URL}).",
-            "",
-        ]
-    )
-    if dataset_tools:
-        lines.extend(_tools_details_block(dataset_tools))
-    return "\n".join(lines)
+        "rows_line": f"Rows: {row_count}" if is_row_dataset else f"JSONL files: {len(trace_files)}",
+    }
+    return _render_card(context, readme_template)
 
 
 def write_traces_readme(
@@ -523,12 +542,15 @@ def write_traces_readme(
     tools: list[dict[str, Any]] | None = None,
     excluded_dirs: list[Path] | None = None,
     extraction_provider: str | None = None,
+    license: str | None = None,
+    card_extra: dict[str, Any] | None = None,
+    readme_template: Path | None = None,
 ) -> Path:
     trace_files = sorted(
         path
         for path in traces_dir.rglob("*.jsonl")
         if path.is_file()
-        and not {"partials", "failures"}.intersection(path.relative_to(traces_dir).parts)
+        and not NON_DATA_TRACE_DIR_NAMES.intersection(path.relative_to(traces_dir).parts)
         and not any(_path_is_relative_to(path, excluded_dir) for excluded_dir in excluded_dirs or [])
     )
     dataset_tools = tools if tools is not None else _dataset_tools(trace_files)
@@ -542,6 +564,11 @@ def write_traces_readme(
             repo_id=repo_id,
             tools=dataset_tools,
             extraction_provider=extraction_provider,
+            reward_stats=_reward_stats(traces_dir, trace_files),
+            data_files=_split_data_files(traces_dir),
+            license=license,
+            card_extra=card_extra,
+            readme_template=readme_template,
         ),
         encoding="utf-8",
     )

--- a/tests/test_agent_cfg.py
+++ b/tests/test_agent_cfg.py
@@ -1,0 +1,45 @@
+"""Tests for the shared agent-config helpers (used by both prompt mode and bench)."""
+
+from teich import agent_cfg
+from teich.config import Config
+
+
+def test_provider_env_key_covers_all_providers():
+    # The full provider map — previously bench only knew openai/openrouter/anthropic.
+    assert agent_cfg.provider_env_key("zai") == "GLM_API_KEY"
+    assert agent_cfg.provider_env_key("z-ai") == "GLM_API_KEY"
+    assert agent_cfg.provider_env_key("deepseek") == "DEEPSEEK_API_KEY"
+    assert agent_cfg.provider_env_key("xai") == "XAI_API_KEY"
+    assert agent_cfg.provider_env_key("grok") == "XAI_API_KEY"
+    assert agent_cfg.provider_env_key("google") == "GOOGLE_API_KEY"
+    assert agent_cfg.provider_env_key("openrouter") == "OPENROUTER_API_KEY"
+    assert agent_cfg.provider_env_key("anthropic") == "ANTHROPIC_API_KEY"
+    assert agent_cfg.provider_env_key("mystery") == "MYSTERY_API_KEY"  # fallback
+
+
+def test_container_base_url_rewrites_host_local():
+    assert agent_cfg.container_base_url("http://localhost:8080/v1") == "http://host.docker.internal:8080/v1"
+    assert agent_cfg.container_base_url("http://127.0.0.1:1234") == "http://host.docker.internal:1234"
+    assert agent_cfg.container_base_url("https://api.z.ai/api/paas/v4") == "https://api.z.ai/api/paas/v4"
+    assert agent_cfg.container_base_url(None) is None
+
+
+def test_bench_auth_env_sets_provider_specific_key_and_rewrites_localhost(monkeypatch):
+    for var in ("TEICH_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "GLM_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = Config(
+        agent={"provider": "pi"},
+        api={"provider": "zai", "base_url": "http://localhost:9000/v1", "api_key": "glm-key"},
+    )
+    env = agent_cfg.bench_auth_env(cfg)
+    assert env["GLM_API_KEY"] == "glm-key"  # the correct var for zai (was dropped before)
+    assert env["TEICH_API_KEY"] == "glm-key"
+    assert env["OPENAI_API_KEY"] == "glm-key"  # compat var for OpenAI-family CLIs
+    assert env["OPENAI_BASE_URL"] == "http://host.docker.internal:9000/v1"  # host-local rewritten
+
+
+def test_pi_prefixed_model_only_prefixes_pi():
+    pi = Config(agent={"provider": "pi"}, api={"provider": "openrouter"}, model={"model": "z-ai/glm-5.2"})
+    assert agent_cfg.pi_prefixed_model(pi) == "openrouter/z-ai/glm-5.2"
+    codex = Config(agent={"provider": "codex"}, api={"provider": "openai"}, model={"model": "gpt-5"})
+    assert agent_cfg.pi_prefixed_model(codex) == "gpt-5"  # non-pi agents get the model unchanged

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -594,6 +594,15 @@ def test_run_bench_drives_sources_and_harvests(tmp_path, monkeypatch):
     assert (tmp_path / "output" / "failed" / f"{base.bench_stem(s, 't2')}.jsonl").is_file()
 
 
+def test_run_bench_raises_when_all_tasks_fail(tmp_path, monkeypatch):
+    # Per-task errors are swallowed; if EVERY dispatched task fails, run_bench must raise (so the
+    # CLI exits non-zero) rather than return empty and look like a successful empty benchmark.
+    fake = _FakeBackend({"t1": RuntimeError("docker boom"), "t2": RuntimeError("docker boom")})
+    monkeypatch.setattr(bench_runner, "get_backend", lambda t: fake)
+    with pytest.raises(RuntimeError, match="all 2 attempted task"):
+        run_bench(_bench_cfg(tmp_path))
+
+
 def test_run_bench_resume_skips_and_failure_continues(tmp_path, monkeypatch):
     s = BenchSource(type="fake", source="S")
     # Pre-harvest t1 so resume skips it; t2 raises (skipped); t3 succeeds.

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -163,6 +163,30 @@ def test_run_bench_rejects_codex_host_auth(tmp_path, monkeypatch):
         run_bench(cfg)
 
 
+def test_run_bench_rejects_chat_wire_api_on_custom_endpoint(tmp_path):
+    # Bench doesn't thread api.wire_api into pi/codex, so a chat-completions-only endpoint (e.g.
+    # z.ai via provider: openai + base_url) would silently be hit on /responses. Fail fast.
+    def _cfg(**api):
+        return Config(
+            agent={"provider": "pi"},
+            api=api,
+            bench={"sources": [{"type": "harbor", "source": "S"}]},
+            output={"traces_dir": tmp_path / "o"},
+        )
+
+    with pytest.raises(RuntimeError, match="does not yet thread api.wire_api"):
+        run_bench(_cfg(provider="openai", base_url="https://api.z.ai/api/paas/v4",
+                       wire_api="chat_completions", api_key="k"))
+    # openrouter is exempt (its prefix routing already uses completions); responses is fine.
+    #  (these get past the guard and fail later for unrelated reasons — assert the guard message is absent)
+    for ok in (dict(provider="openrouter", wire_api="chat_completions", api_key="k"),
+               dict(provider="openai", wire_api="responses", api_key="k")):
+        try:
+            run_bench(_cfg(**ok))
+        except RuntimeError as exc:
+            assert "does not yet thread api.wire_api" not in str(exc)
+
+
 def test_existing_output_across_splits(tmp_path):
     cfg = Config(output={"traces_dir": tmp_path / "output"})
     assert base.existing_output(cfg, "bench-x") is None

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -151,6 +151,13 @@ def test_bench_root_rejects_in_tree_bench_dir(tmp_path):
         base.bench_root(Config(output={"traces_dir": tmp_path / "out", "bench_dir": tmp_path / "out"}))
 
 
+def test_bench_root_default_rejects_output_named_bench(tmp_path):
+    # --output bench makes the computed default sibling (traces_dir.parent/"bench") collide with
+    # the dataset dir; the default must be guarded too, not just an explicit output.bench_dir.
+    with pytest.raises(RuntimeError, match="must be outside"):
+        base.bench_root(Config(output={"traces_dir": tmp_path / "bench"}))
+
+
 # ------------------------------------------------------------------- base: harvest
 
 def test_harvest_writes_native_trace_and_metadata(tmp_path):
@@ -173,6 +180,26 @@ def test_harvest_writes_native_trace_and_metadata(tmp_path):
     assert meta["rewards"] == {"reward": 0.6, "tests": 0.8}            # full dict, no clamping
     assert meta["source"] == "terminal-bench-2.0" and meta["type"] == "harbor"
     assert meta["agent"] == "pi" and meta["model"] == "z-ai/glm-5.2"
+
+
+def test_harvest_reroute_removes_stale_split_copy(tmp_path):
+    # Re-harvesting a task (no --resume) whose score crosses a routing boundary must not leave a
+    # stale copy in the old split — the dataset scanners read every split.
+    cfg = Config(agent={"provider": "pi"}, output={"traces_dir": tmp_path / "output"})
+    source = BenchSource(type="harbor", source="ds")
+    task = base.BenchTask(id="t")
+    stem = base.bench_stem(source, "t")
+    base.harvest(cfg, source, task, base.BenchRun(native_lines=['{"type":"session"}'], rewards={"reward": 0.0}))
+    assert (tmp_path / "output" / "failed" / f"{stem}.jsonl").is_file()
+
+    paths, split = base.harvest(
+        cfg, source, task, base.BenchRun(native_lines=['{"type":"session"}'], rewards={"reward": 1.0})
+    )
+    assert split == "passed"
+    assert (tmp_path / "output" / "passed" / f"{stem}.jsonl").is_file()
+    assert not (tmp_path / "output" / "failed" / f"{stem}.jsonl").exists()
+    meta = json.loads((tmp_path / "output" / "metadata" / f"{stem}.json").read_text(encoding="utf-8"))
+    assert meta["split"] == "passed"
 
 
 # ------------------------------------------------------------------- harbor backend helpers

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -87,6 +87,46 @@ def test_source_id_distinguishes_by_knobs():
     assert base.source_id(BenchSource(type="swe-bench", source="ds")) == "ds"
 
 
+def test_source_id_bounds_large_instance_list():
+    # A big instances subset must not leak its full comma-joined list into source_id (and thus
+    # into filenames / Docker tags / container names past OS/Docker length limits).
+    many = [f"repo__proj-{i:04d}" for i in range(30)]
+    src = BenchSource(type="swe-bench", source="ds", instances=many)
+    sid = base.source_id(src)
+    assert len(sid) < 60 and "repo__proj-0029" not in sid
+    # order-independent (listing order shouldn't spawn a distinct id / dataset)
+    assert base.source_id(BenchSource(type="swe-bench", source="ds", instances=list(reversed(many)))) == sid
+    # distinct instance sets stay distinct
+    assert base.source_id(BenchSource(type="swe-bench", source="ds", instances=many[:15])) != sid
+    # a single instance stays human-readable
+    assert "django__django-1" in base.source_id(
+        BenchSource(type="swe-bench", source="ds", instances=["django__django-1"])
+    )
+
+
+def test_harbor_source_slug_keys_on_repo():
+    # Same spec/version but different repo must not share a download cache dir (else the second
+    # source silently reuses the first repo's tasks). Absent repo, the key is unchanged.
+    assert hb._source_slug("ds", "1.0") == hb._source_slug("ds", "1.0", None)
+    assert hb._source_slug("ds", "1.0", "orgA/reg") != hb._source_slug("ds", "1.0", "orgB/reg")
+    assert hb._source_slug("ds", "1.0", "orgA/reg") != hb._source_slug("ds", "1.0")
+
+
+def test_run_bench_rejects_codex_host_auth(tmp_path, monkeypatch):
+    # Bench backends don't wire Codex host auth into the task container; fail fast rather than
+    # launch a silently-unauthenticated run when host auth is the only configured credential.
+    for var in ("TEICH_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = Config(
+        agent={"provider": "codex", "codex": {"use_host_auth": True}},
+        bench={"sources": [{"type": "harbor", "source": "terminal-bench@2.0"}]},
+        output={"traces_dir": tmp_path / "o"},
+    )
+    assert cfg.get_api_key() is None
+    with pytest.raises(RuntimeError, match="does not yet support Codex host auth"):
+        run_bench(cfg)
+
+
 def test_existing_output_across_splits(tmp_path):
     cfg = Config(output={"traces_dir": tmp_path / "output"})
     assert base.existing_output(cfg, "bench-x") is None

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -256,6 +256,40 @@ def test_harbor_image_names_computed_and_from_trial():
     assert "hb__custom" in names and "hb__my-task" in names
 
 
+def test_harbor_image_names_include_prebuilt_docker_image(tmp_path):
+    """A task with ``[environment].docker_image`` runs in harbor's prebuilt mode: no hb__
+    image is ever built, and harbor's ``down --rmi local`` teardown never removes a pulled
+    tagged image — so the purge list must carry the task.toml name (with or without a trial)."""
+    pytest.importorskip("tomllib")  # py3.11+; the harbor backend itself requires 3.12
+    import types as _t
+
+    task_dir = tmp_path / "fix-ocaml-gc"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text(
+        '[environment]\ndocker_image = "alexgshaw/fix-ocaml-gc:20251031"\n'
+        '[verifier.environment]\ndocker_image = "alexgshaw/verifier:v1"\n',
+        encoding="utf-8",
+    )
+    names = hb._harbor_image_names(None, "fix-ocaml-gc", task_dir)
+    assert "alexgshaw/fix-ocaml-gc:20251031" in names
+    assert "alexgshaw/verifier:v1" in names  # a separate verifier env's prebuilt image too
+    assert "hb__fix-ocaml-gc" in names  # deterministic hb__ fallback still present
+
+    trial = _t.SimpleNamespace(
+        agent_environment=_t.SimpleNamespace(_main_image_name="hb__custom"),
+        verifier_environment=None,
+        task=_t.SimpleNamespace(short_name="fix-ocaml-gc"),
+    )
+    assert "alexgshaw/fix-ocaml-gc:20251031" in hb._harbor_image_names(trial, "fix-ocaml-gc", task_dir)
+
+
+def test_harbor_image_names_tolerate_missing_or_bad_task_toml(tmp_path):
+    assert hb._harbor_image_names(None, "t", tmp_path) == ["hb__t"]  # no task.toml
+    (tmp_path / "task.toml").write_text("not = valid [ toml", encoding="utf-8")
+    assert hb._harbor_image_names(None, "t", tmp_path) == ["hb__t"]  # unparseable -> best-effort
+    assert hb._harbor_image_names(None, "t", None) == ["hb__t"]  # no task dir at all
+
+
 def test_purge_images_invokes_docker_rmi(monkeypatch):
     calls = []
     monkeypatch.setattr(hb.subprocess, "run", lambda args, **kw: calls.append(args))
@@ -316,6 +350,100 @@ def test_harbor_run_purges_fallback_image_when_trial_fails(monkeypatch, tmp_path
             Config(output={"traces_dir": tmp_path / "o"}), src, base.BenchTask(id="my_task", raw=tmp_path)
         )
     assert purged == ["hb__my_task"]  # trial=None -> deterministic fallback (underscore preserved)
+
+
+def test_harbor_run_purges_prebuilt_image_on_interrupt(monkeypatch, tmp_path):
+    """Ctrl-C mid-task (KeyboardInterrupt, no trial yet): the finally must still purge the
+    prebuilt task image — terminal-bench tasks are all prebuilt, so leaving it leaks GBs."""
+    pytest.importorskip("tomllib")
+    task_dir = tmp_path / "t1"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text('[environment]\ndocker_image = "example/t1:v1"\n', encoding="utf-8")
+    monkeypatch.setattr(hb, "_build_trial_config", lambda *_a, **_k: object())
+
+    def _interrupt(_config):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(hb, "_create_and_run", _interrupt)
+    purged: list[str] = []
+    monkeypatch.setattr(hb, "_purge_images", purged.extend)
+
+    with pytest.raises(KeyboardInterrupt):
+        hb.HarborBackend().run(
+            Config(output={"traces_dir": tmp_path / "o"}),
+            BenchSource(type="harbor", source="S"),
+            base.BenchTask(id="t1", raw=task_dir),
+        )
+    assert "example/t1:v1" in purged
+    assert "hb__t1" in purged
+
+
+def test_harbor_run_keeps_prebuilt_image_shared_across_tasks(monkeypatch, tmp_path):
+    """A prebuilt image declared by more than one task in the source must NOT be purged
+    per-task: rmi'ing it can race a concurrent sibling's `compose up` (No such image) and
+    forces a re-pull per task. Only images unique to the task are removed."""
+    pytest.importorskip("tomllib")
+    root = tmp_path / "tasks"
+    for name, image in (("t1", "example/shared:v1"), ("t2", "example/shared:v1"), ("t3", "example/solo:v1")):
+        d = root / name
+        d.mkdir(parents=True)
+        (d / "task.toml").write_text(f'[environment]\ndocker_image = "{image}"\n', encoding="utf-8")
+    monkeypatch.setattr(hb, "_build_trial_config", lambda *_a, **_k: object())
+
+    def _explode(_config):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(hb, "_create_and_run", _explode)
+    purged: list[str] = []
+    monkeypatch.setattr(hb, "_purge_images", purged.extend)
+
+    cfg = Config(output={"traces_dir": tmp_path / "o"})
+    src = BenchSource(type="harbor", source=str(root))
+    backend = hb.HarborBackend()
+    tasks = {t.id: t for t in backend.tasks(cfg, src)}
+
+    with pytest.raises(RuntimeError):
+        backend.run(cfg, src, tasks["t1"])
+    assert "example/shared:v1" not in purged  # t2 declares the same image
+    assert "hb__t1" in purged  # per-task hb__ name still purged
+
+    purged.clear()
+    with pytest.raises(RuntimeError):
+        backend.run(cfg, src, tasks["t3"])
+    assert "example/solo:v1" in purged  # unique to t3 -> purged
+
+
+def test_harbor_run_purges_image_duplicated_within_one_task(monkeypatch, tmp_path):
+    """One task declaring the same image for both its agent and verifier environments is
+    NOT sharing across tasks: the image is still unique to the task and must be purged."""
+    pytest.importorskip("tomllib")
+    root = tmp_path / "tasks"
+    d1, d2 = root / "t1", root / "t2"
+    d1.mkdir(parents=True)
+    (d1 / "task.toml").write_text(
+        '[environment]\ndocker_image = "example/both:v1"\n'
+        '[verifier.environment]\ndocker_image = "example/both:v1"\n',
+        encoding="utf-8",
+    )
+    d2.mkdir()
+    (d2 / "task.toml").write_text('[environment]\ndocker_image = "example/other:v1"\n', encoding="utf-8")
+    monkeypatch.setattr(hb, "_build_trial_config", lambda *_a, **_k: object())
+
+    def _explode(_config):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(hb, "_create_and_run", _explode)
+    purged: list[str] = []
+    monkeypatch.setattr(hb, "_purge_images", purged.extend)
+
+    cfg = Config(output={"traces_dir": tmp_path / "o"})
+    src = BenchSource(type="harbor", source=str(root))
+    backend = hb.HarborBackend()
+    tasks = {t.id: t for t in backend.tasks(cfg, src)}
+
+    with pytest.raises(RuntimeError):
+        backend.run(cfg, src, tasks["t1"])
+    assert "example/both:v1" in purged  # duplicated within t1 only -> still unique -> purged
 
 
 def test_harbor_resolve_task_dirs(tmp_path):

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,467 @@
+"""Tests for bench mode: config (sources array), the shared backend base/harvest, the
+harbor backend, and the driver loop. Live harbor/Docker runs stay integration-only; here we
+cover config, reward/route/harvest, harbor resolution/normalization, and driver behavior."""
+
+import json
+
+import pytest
+
+from teich.bench import run_bench
+from teich.bench import runner as bench_runner
+from teich.bench.backends import base, get_backend
+from teich.bench.backends import harbor as hb
+from teich.config import BenchSource, Config
+
+
+# --------------------------------------------------------------------------- config
+
+def test_bench_config_defaults():
+    assert Config().bench.sources == []
+
+
+def test_bench_sources_from_yaml(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "bench:\n"
+        "  sources:\n"
+        "    - { type: harbor, source: terminal-bench@2.0 }\n"
+        "    - { type: swe-bench, source: SWE-bench/SWE-bench_Verified, split: test }\n",
+        encoding="utf-8",
+    )
+    cfg = Config.from_yaml(config_file)
+    assert [s.type for s in cfg.bench.sources] == ["harbor", "swe-bench"]
+    assert cfg.bench.sources[0].source == "terminal-bench@2.0"
+    assert cfg.bench.sources[0].backend == "docker"          # default
+    assert cfg.bench.sources[1].split == "test"
+
+
+def test_run_bench_requires_sources():
+    with pytest.raises(RuntimeError, match="bench.sources"):
+        run_bench(Config())
+
+
+def test_get_backend():
+    assert get_backend("harbor").type == "harbor"
+    with pytest.raises(RuntimeError, match="Unknown bench source type"):
+        get_backend("nope")
+
+
+# ------------------------------------------------------------------- base: scoring/routing
+
+def test_numeric_primary_route():
+    assert base.numeric(1) == 1.0 and base.numeric(True) is None and base.numeric("x") is None
+    assert base.primary_score({"reward": 1.0, "sub": 0.5}) == 1.0   # 'reward' preferred
+    assert base.primary_score({"score": 0.6}) == 0.6                # else first numeric
+    assert base.primary_score(None) is None
+    assert base.route_split(1.0) == "passed"
+    assert base.route_split(0.0) == "failed"
+    assert base.route_split(None) == "failed"
+    assert base.route_split(0.6) == "borderline"
+
+
+def test_rewards_from_mapping_keeps_full_dict():
+    assert base.rewards_from_mapping({"rewards": {"reward": 1.0, "sub": 0.5, "bad": "x"}}) == {
+        "reward": 1.0,
+        "sub": 0.5,
+    }
+    assert base.rewards_from_mapping({"rewards": {}}) is None
+    assert base.rewards_from_mapping(None) is None
+
+
+def test_bench_stem_namespaced_by_source():
+    s = BenchSource(type="harbor", source="terminal-bench@2.0")
+    assert base.bench_stem(s, "task-a") == "bench-terminal-bench-2.0-task-a"
+    s2 = BenchSource(type="swe-bench", source="SWE-bench/SWE-bench_Verified")
+    assert base.bench_stem(s2, "astropy__astropy-12907") == (
+        "bench-SWE-bench-SWE-bench_Verified-astropy__astropy-12907"
+    )
+
+
+def test_source_id_distinguishes_by_knobs():
+    # Same `source` but a differing knob (split) must yield distinct ids/stems so the two
+    # sources can't overwrite each other or wrongly resume-skip; the plain case is unchanged.
+    a = BenchSource(type="swe-bench", source="ds", split="train")
+    b = BenchSource(type="swe-bench", source="ds", split="test")
+    assert base.source_id(a) != base.source_id(b)
+    assert base.bench_stem(a, "t") != base.bench_stem(b, "t")
+    assert base.source_id(BenchSource(type="swe-bench", source="ds")) == "ds"
+
+
+def test_existing_output_across_splits(tmp_path):
+    cfg = Config(output={"traces_dir": tmp_path / "output"})
+    assert base.existing_output(cfg, "bench-x") is None
+    routed = tmp_path / "output" / "borderline" / "bench-x.jsonl"
+    routed.parent.mkdir(parents=True)
+    routed.write_text("{}\n", encoding="utf-8")
+    assert base.existing_output(cfg, "bench-x") == routed
+
+
+def test_bench_root_sibling_of_output(tmp_path):
+    cfg = Config(output={"traces_dir": tmp_path / "out"})
+    assert base.bench_root(cfg) == tmp_path / "bench"
+    cfg2 = Config(output={"traces_dir": tmp_path / "out", "bench_dir": tmp_path / "custom"})
+    assert base.bench_root(cfg2) == tmp_path / "custom"
+
+
+def test_bench_root_rejects_in_tree_bench_dir(tmp_path):
+    # A bench_dir inside traces_dir would get uploaded + misclassified as dataset rows.
+    with pytest.raises(RuntimeError, match="must be outside"):
+        base.bench_root(Config(output={"traces_dir": tmp_path / "out", "bench_dir": tmp_path / "out" / "bench"}))
+    with pytest.raises(RuntimeError, match="must be outside"):
+        base.bench_root(Config(output={"traces_dir": tmp_path / "out", "bench_dir": tmp_path / "out"}))
+
+
+# ------------------------------------------------------------------- base: harvest
+
+def test_harvest_writes_native_trace_and_metadata(tmp_path):
+    cfg = Config(agent={"provider": "pi"}, output={"traces_dir": tmp_path / "output"})
+    source = BenchSource(type="harbor", source="terminal-bench@2.0")
+    task = base.BenchTask(id="add-bug")
+    run = base.BenchRun(
+        native_lines=['{"type":"session","id":"s"}', '{"type":"message","message":{"role":"user","content":[]}}'],
+        rewards={"reward": 0.6, "tests": 0.8},
+        metadata={"model": "z-ai/glm-5.2", "exception": None},
+    )
+    paths, split = base.harvest(cfg, source, task, run)
+    stem = base.bench_stem(source, "add-bug")
+    assert split == "borderline"
+    assert paths == [tmp_path / "output" / "borderline" / f"{stem}.jsonl"]
+    rows = [json.loads(line) for line in paths[0].read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert {row.get("type") for row in rows} == {"session", "message"}  # native, not converted
+    meta = json.loads((tmp_path / "output" / "metadata" / f"{stem}.json").read_text(encoding="utf-8"))
+    assert meta["split"] == "borderline" and meta["reward"] == 0.6
+    assert meta["rewards"] == {"reward": 0.6, "tests": 0.8}            # full dict, no clamping
+    assert meta["source"] == "terminal-bench-2.0" and meta["type"] == "harbor"
+    assert meta["agent"] == "pi" and meta["model"] == "z-ai/glm-5.2"
+
+
+# ------------------------------------------------------------------- harbor backend helpers
+
+def test_harbor_agent_name_mapping():
+    assert hb._agent_name_for("codex") == "codex"
+    assert hb._agent_name_for("claude-code") == "claude-code"
+    assert hb._agent_name_for("claude") == "claude-code"
+    assert hb._agent_name_for("pi") == "pi"
+    assert hb._agent_name_for("hermes") == "hermes"
+    with pytest.raises(RuntimeError, match="does not support agent provider"):
+        hb._agent_name_for("chat")
+
+
+def test_harbor_auth_env():
+    env = hb._agent_auth_env(
+        Config(api={"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "sk"})
+    )
+    assert env["OPENAI_API_KEY"] == "sk" and env["OPENROUTER_API_KEY"] == "sk"
+    assert env["OPENAI_BASE_URL"] == "https://openrouter.ai/api/v1"
+    env2 = hb._agent_auth_env(Config(api={"provider": "openai", "api_key": "sk-o"}))
+    assert env2["OPENAI_API_KEY"] == "sk-o" and "OPENROUTER_API_KEY" not in env2
+
+
+def test_harbor_model_prefix():
+    pi_or = Config(agent={"provider": "pi"}, model={"model": "z-ai/glm-5.2"}, api={"provider": "openrouter"})
+    assert hb._bench_model_name(pi_or) == "openrouter/z-ai/glm-5.2"
+    already = Config(agent={"provider": "pi"}, model={"model": "openrouter/z-ai/glm-5.2"}, api={"provider": "openrouter"})
+    assert hb._bench_model_name(already) == "openrouter/z-ai/glm-5.2"
+    codex = Config(agent={"provider": "codex"}, model={"model": "z-ai/glm-5.2"}, api={"provider": "openrouter"})
+    assert hb._bench_model_name(codex) == "z-ai/glm-5.2"
+
+
+def test_harbor_classify_remote_source():
+    assert hb._classify_remote_source("terminal-bench@2.0", None, None) == ("registry", "terminal-bench@2.0")
+    assert hb._classify_remote_source("terminal-bench", None, "2.0") == ("registry", "terminal-bench@2.0")
+    assert hb._classify_remote_source("org/name", None, None) == ("package", "org/name@latest")
+    assert hb._classify_remote_source("org/name@ref", None, None) == ("package", "org/name@ref")
+    assert hb._classify_remote_source("ds", "https://github.com/o/r", None) == ("repo", "ds")
+
+
+def test_harbor_image_names_computed_and_from_trial():
+    import types as _t
+
+    # No trial (error path): the deterministic sanitize("hb__" + task id), lowercased.
+    assert hb._harbor_image_names(None, "Adaptive-Rejection-Sampler") == ["hb__adaptive-rejection-sampler"]
+    # With a trial: prefer the actual env image name(s) AND include the computed one.
+    trial = _t.SimpleNamespace(
+        agent_environment=_t.SimpleNamespace(_main_image_name="hb__custom"),
+        verifier_environment=None,
+        task=_t.SimpleNamespace(short_name="my-task"),
+    )
+    names = hb._harbor_image_names(trial, "ignored")
+    assert "hb__custom" in names and "hb__my-task" in names
+
+
+def test_purge_images_invokes_docker_rmi(monkeypatch):
+    calls = []
+    monkeypatch.setattr(hb.subprocess, "run", lambda args, **kw: calls.append(args))
+    hb._purge_images(["hb__a", "hb__b"])
+    assert calls == [["docker", "rmi", "-f", "hb__a"], ["docker", "rmi", "-f", "hb__b"]]
+
+
+def test_purge_images_swallows_errors(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("no docker")
+
+    monkeypatch.setattr(hb.subprocess, "run", boom)
+    hb._purge_images(["hb__a"])  # best-effort: must not raise
+
+
+def test_harbor_run_purges_image_unless_kept(monkeypatch, tmp_path):
+    import types as _t
+
+    fake_trial = _t.SimpleNamespace(
+        agent_environment=_t.SimpleNamespace(_main_image_name="hb__t1"),
+        verifier_environment=None,
+        task=_t.SimpleNamespace(short_name="t1"),
+    )
+    fake_result = _t.SimpleNamespace(exception_info=None, verifier_result={"rewards": {"reward": 1.0}})
+    monkeypatch.setattr(hb, "_build_trial_config", lambda *_a, **_k: object())
+    monkeypatch.setattr(hb, "_create_and_run", lambda _config: "coro")
+    monkeypatch.setattr(hb.asyncio, "run", lambda _coro: (fake_trial, fake_result))
+    monkeypatch.setattr(hb, "_agent_dir", lambda _trial: None)
+    purged: list[str] = []
+    monkeypatch.setattr(hb, "_purge_images", purged.extend)
+    src = BenchSource(type="harbor", source="S")
+
+    hb.HarborBackend().run(Config(output={"traces_dir": tmp_path / "o"}), src, base.BenchTask(id="t1", raw=tmp_path))
+    assert "hb__t1" in purged
+
+    purged.clear()
+    kept = Config(output={"traces_dir": tmp_path / "o2", "keep_bench_images": True})
+    hb.HarborBackend().run(kept, src, base.BenchTask(id="t1", raw=tmp_path))
+    assert purged == []  # keep_bench_images -> no purge
+
+
+def test_harbor_run_purges_fallback_image_when_trial_fails(monkeypatch, tmp_path):
+    """When _create_and_run blows up before returning a trial, the finally still purges the
+    deterministic sanitize("hb__" + task_id) fallback so a failed setup can't leak its image."""
+    monkeypatch.setattr(hb, "_build_trial_config", lambda *_a, **_k: object())
+
+    def _explode(_config):
+        raise RuntimeError("setup failed before any trial")
+
+    # _create_and_run(config) raises while building asyncio.run's argument, so trial stays None.
+    monkeypatch.setattr(hb, "_create_and_run", _explode)
+    purged: list[str] = []
+    monkeypatch.setattr(hb, "_purge_images", purged.extend)
+    src = BenchSource(type="harbor", source="S")
+
+    with pytest.raises(RuntimeError, match="setup failed"):
+        hb.HarborBackend().run(
+            Config(output={"traces_dir": tmp_path / "o"}), src, base.BenchTask(id="my_task", raw=tmp_path)
+        )
+    assert purged == ["hb__my_task"]  # trial=None -> deterministic fallback (underscore preserved)
+
+
+def test_harbor_resolve_task_dirs(tmp_path):
+    single = tmp_path / "one"
+    single.mkdir()
+    (single / "task.toml").write_text("", encoding="utf-8")
+    assert hb._resolve_task_dirs(single) == [single]
+    coll = tmp_path / "many"
+    (coll / "a").mkdir(parents=True)
+    (coll / "a" / "task.toml").write_text("", encoding="utf-8")
+    (coll / "b").mkdir()
+    (coll / "b" / "task.toml").write_text("", encoding="utf-8")
+    assert hb._resolve_task_dirs(coll) == [coll / "a", coll / "b"]
+    with pytest.raises(RuntimeError, match="No Harbor tasks"):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        hb._resolve_task_dirs(empty)
+
+
+# A minimal pi `--mode json` stream (as harbor's --no-session pi run emits to pi.txt).
+_PI_STREAM_LINES = [
+    'Warning: Model "z-ai/glm-5.2" not found for provider "openrouter". Using custom model id.',
+    json.dumps({"type": "session", "version": 3, "id": "abc", "cwd": "/app"}),
+    json.dumps({"type": "agent_start"}),
+    json.dumps({"type": "message_end", "message": {"role": "user", "content": [{"type": "text", "text": "Fix add()"}]}}),
+    json.dumps({"type": "message_end", "message": {"role": "assistant", "provider": "openrouter",
+        "model": "z-ai/glm-5.2", "content": [{"type": "text", "text": "Fixed."}]}}),
+]
+
+
+def test_pi_stream_to_session_events(tmp_path):
+    pi_txt = tmp_path / "pi.txt"
+    pi_txt.write_text("\n".join(_PI_STREAM_LINES) + "\n", encoding="utf-8")
+    events = hb._pi_stream_to_session_events(pi_txt)
+    assert [e["type"] for e in events] == ["session", "message", "model_change", "message"]
+    mc = next(e for e in events if e["type"] == "model_change")
+    assert mc == {"type": "model_change", "provider": "openrouter", "modelId": "z-ai/glm-5.2"}
+
+
+def test_native_trace_pi_stream(tmp_path):
+    cfg = Config(output={"traces_dir": tmp_path / "output"})
+    source = BenchSource(type="harbor", source="S")
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "pi.txt").write_text("\n".join(_PI_STREAM_LINES) + "\n", encoding="utf-8")
+    lines, native_dir = hb._native_trace(cfg, source, agent_dir, "add-bug")
+    # session dir is namespaced by source so concurrent same-named tasks can't race
+    assert lines and native_dir == tmp_path / "bench" / "sessions" / base.bench_stem(source, "add-bug")
+    assert (native_dir / "pi.jsonl").is_file()
+    types = {json.loads(line)["type"] for line in lines}
+    assert "session" in types and "message" in types
+
+
+def test_rewards_from_result_and_files(tmp_path):
+    class R:
+        verifier_result = {"rewards": {"reward": 1.0, "sub": 0.5}}
+    assert hb._rewards_from_result(R()) == {"reward": 1.0, "sub": 0.5}
+
+    class N:
+        verifier_result = None
+    assert hb._rewards_from_result(N()) is None
+
+    d = tmp_path / "trial"
+    d.mkdir()
+    (d / "reward.txt").write_text("0.0\n", encoding="utf-8")
+    assert hb._rewards_from_files(d) == {"reward": 0.0}
+
+
+# ------------------------------------------------------------------- harbor backend run/tasks
+
+def test_harbor_tasks_local(tmp_path):
+    pytest.importorskip("harbor")
+    tasks_dir = tmp_path / "tasks"
+    (tasks_dir / "add-bug").mkdir(parents=True)
+    (tasks_dir / "add-bug" / "task.toml").write_text("", encoding="utf-8")
+    cfg = Config(output={"traces_dir": tmp_path / "output"})
+    source = BenchSource(type="harbor", source=str(tasks_dir))
+    tasks = list(hb.HarborBackend().tasks(cfg, source))
+    assert [t.id for t in tasks] == ["add-bug"]
+
+
+def test_harbor_run_builds_benchrun_from_trial(tmp_path, monkeypatch):
+    pytest.importorskip("harbor")
+    agent_dir = tmp_path / "trial" / "agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "pi.txt").write_text("\n".join(_PI_STREAM_LINES) + "\n", encoding="utf-8")
+
+    class _Trial:
+        paths = type("P", (), {"agent_dir": agent_dir})()
+
+    class _Result:
+        verifier_result = {"rewards": {"reward": 1.0}}
+        exception_info = None
+
+    async def _fake_create_and_run(config):
+        return _Trial(), _Result()
+
+    monkeypatch.setattr(hb, "_create_and_run", _fake_create_and_run)
+    monkeypatch.setattr(hb, "_build_trial_config", lambda cfg, source, task_dir, trials_dir: object())
+    cfg = Config(agent={"provider": "pi"}, output={"traces_dir": tmp_path / "output"})
+    source = BenchSource(type="harbor", source="terminal-bench@2.0")
+    run = hb.HarborBackend().run(cfg, source, base.BenchTask(id="add-bug", raw=tmp_path / "task"))
+    assert run.rewards == {"reward": 1.0}
+    assert run.native_lines and run.metadata.get("exception") is None
+
+
+# ------------------------------------------------------------------- driver
+
+class _FakeBackend:
+    type = "fake"
+
+    def __init__(self, runs):
+        self.runs = runs
+        self.ran: list[str] = []
+
+    def require(self):
+        pass
+
+    def tasks(self, cfg, source, *, refresh=False):
+        return [base.BenchTask(id=task_id) for task_id in self.runs]
+
+    def run(self, cfg, source, task):
+        self.ran.append(task.id)
+        result = self.runs[task.id]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _bench_cfg(tmp_path):
+    return Config(
+        agent={"provider": "pi"},
+        bench={"sources": [{"type": "fake", "source": "S"}]},
+        output={"traces_dir": tmp_path / "output"},
+    )
+
+
+def test_run_bench_drives_sources_and_harvests(tmp_path, monkeypatch):
+    fake = _FakeBackend({
+        "t1": base.BenchRun(native_lines=['{"type":"session"}'], rewards={"reward": 1.0}),
+        "t2": base.BenchRun(native_lines=['{"type":"session"}'], rewards={"reward": 0.0}),
+    })
+    monkeypatch.setattr(bench_runner, "get_backend", lambda t: fake)
+    written = run_bench(_bench_cfg(tmp_path))
+    assert len(written) == 2 and fake.ran == ["t1", "t2"]
+    s = BenchSource(type="fake", source="S")
+    assert (tmp_path / "output" / "passed" / f"{base.bench_stem(s, 't1')}.jsonl").is_file()
+    assert (tmp_path / "output" / "failed" / f"{base.bench_stem(s, 't2')}.jsonl").is_file()
+
+
+def test_run_bench_resume_skips_and_failure_continues(tmp_path, monkeypatch):
+    s = BenchSource(type="fake", source="S")
+    # Pre-harvest t1 so resume skips it; t2 raises (skipped); t3 succeeds.
+    done = tmp_path / "output" / "passed" / f"{base.bench_stem(s, 't1')}.jsonl"
+    done.parent.mkdir(parents=True)
+    done.write_text('{"type":"session"}\n', encoding="utf-8")
+    fake = _FakeBackend({
+        "t1": base.BenchRun(native_lines=['{"x":1}'], rewards={"reward": 1.0}),
+        "t2": RuntimeError("docker boom"),
+        "t3": base.BenchRun(native_lines=['{"type":"session"}'], rewards={"reward": 1.0}),
+    })
+    monkeypatch.setattr(bench_runner, "get_backend", lambda t: fake)
+    run_bench(_bench_cfg(tmp_path), resume=True)
+    assert "t1" not in fake.ran  # skipped via resume
+    assert fake.ran == ["t2", "t3"]
+    assert (tmp_path / "output" / "passed" / f"{base.bench_stem(s, 't3')}.jsonl").is_file()
+
+
+def test_run_bench_unknown_type_aborts(tmp_path):
+    # An unregistered source type -> a clear unknown-type error (harbor + swe-bench are known).
+    cfg = Config(bench={"sources": [{"type": "nope", "source": "x"}]}, output={"traces_dir": tmp_path / "o"})
+    with pytest.raises(RuntimeError, match="Unknown bench source type"):
+        run_bench(cfg)
+
+
+def test_run_bench_honors_max_concurrency(tmp_path, monkeypatch):
+    import threading
+
+    max_workers = 3
+    # A barrier makes "the pool parallelizes up to the cap" deterministic instead of
+    # sleep-timing-dependent: exactly max_workers tasks must be in-flight to release each wave.
+    barrier = threading.Barrier(max_workers, timeout=10)
+    state = {"current": 0, "peak": 0}
+    lock = threading.Lock()
+
+    class _ConcBackend:
+        type = "fake"
+
+        def require(self):
+            pass
+
+        def tasks(self, cfg, source, *, refresh=False):
+            return [base.BenchTask(id=f"t{i}") for i in range(6)]
+
+        def run(self, cfg, source, task):
+            with lock:
+                state["current"] += 1
+                state["peak"] = max(state["peak"], state["current"])
+            try:
+                barrier.wait()  # blocks until max_workers are concurrently in-flight
+            except threading.BrokenBarrierError:
+                pass
+            with lock:
+                state["current"] -= 1
+            return base.BenchRun(native_lines=['{"type":"session"}'], rewards={"reward": 1.0})
+
+    monkeypatch.setattr(bench_runner, "get_backend", lambda t: _ConcBackend())
+    cfg = Config(
+        agent={"provider": "pi"},
+        bench={"sources": [{"type": "fake", "source": "S"}]},
+        output={"traces_dir": tmp_path / "output"},
+        max_concurrency=max_workers,
+    )
+    written = run_bench(cfg)
+    assert len(written) == 6
+    assert state["peak"] == max_workers  # pool parallelizes exactly up to the cap

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -104,6 +104,42 @@ def test_source_id_bounds_large_instance_list():
     )
 
 
+def test_bench_source_namespace_field():
+    # swe-bench image namespace: default "swebench" pulls published images; null builds custom
+    # instances locally. (The pull/build execution itself is Docker/integration-only.)
+    assert BenchSource(type="swe-bench", source="ds").namespace == "swebench"
+    assert BenchSource(type="swe-bench", source="ds", namespace=None).namespace is None
+
+
+def test_bench_progress_tracks_counts_when_disabled():
+    # No terminal -> no live bar, but the pass/fail/borderline/error tally is still tracked.
+    p = bench_runner._BenchProgress(console=None)
+    assert not p.enabled
+    with p:
+        bar = p.add_source("swe: ds", 4)
+        assert bar is None
+        p.advance(bar, split="passed")
+        p.advance(bar, split="borderline")
+        p.advance(bar, split="failed")
+        p.advance(bar, errored=True)
+    assert (p.passed, p.failed, p.borderline, p.errored) == (1, 1, 1, 1)
+
+
+def test_bench_progress_renders_with_terminal_console():
+    # A forced-terminal console builds the rich Progress; exercises the column/field wiring
+    # (e.g. the `tally` field must be supplied to add_task) without asserting rendered output.
+    from rich.console import Console
+
+    p = bench_runner._BenchProgress(Console(force_terminal=True))
+    assert p.enabled
+    with p:
+        bar = p.add_source("swe: ds", 2)
+        assert bar is not None
+        p.advance(bar, split="passed")
+        p.advance(bar, errored=True)
+    assert (p.passed, p.errored) == (1, 1)
+
+
 def test_harbor_source_slug_keys_on_repo():
     # Same spec/version but different repo must not share a download cache dir (else the second
     # source silently reuses the first repo's tasks). Absent repo, the key is unchanged.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,28 @@ def test_generate_bench_refuses_to_mix_with_prompts_output(tmp_path: Path):
     assert "already contains prompts-mode data" in " ".join(result.output.split())
 
 
+def test_generate_bench_writes_readme_for_partial_dataset_on_failure(tmp_path: Path, monkeypatch):
+    # An earlier bench source may harvest rows before a later one fails; the partial dataset must
+    # still get a README (like prompt mode) even though the CLI exits non-zero.
+    output = tmp_path / "output"
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        f"agent:\n  provider: pi\nbench:\n  sources:\n    - {{type: harbor, source: {tmp_path}/tasks}}\noutput:\n  traces_dir: {output}\n",
+        encoding="utf-8",
+    )
+
+    def _partial_then_fail(cfg, **kwargs):
+        row = cfg.output.traces_dir / "passed" / "bench-x.jsonl"
+        row.parent.mkdir(parents=True, exist_ok=True)
+        row.write_text('{"messages": []}\n', encoding="utf-8")
+        raise RuntimeError("a later bench source blew up")
+
+    monkeypatch.setattr("teich.bench.run_bench", _partial_then_fail)
+    result = runner.invoke(app, ["generate", "-c", str(config_file), "--mode", "bench"])
+    assert result.exit_code == 1
+    assert (output / "README.md").exists()  # partial dataset still documented
+
+
 def test_generate_prompts_refuses_to_mix_with_bench_output(tmp_path: Path):
     output = tmp_path / "output"
     output.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,65 @@ def test_generate_command_missing_config():
     assert "not found" in result.output
 
 
+def test_generate_rejects_unknown_mode(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("prompts:\n  - hello\n", encoding="utf-8")
+    result = runner.invoke(app, ["generate", "-c", str(config_file), "--mode", "wat"])
+    assert result.exit_code == 1
+    assert "Unknown --mode" in result.output
+
+
+def test_generate_bench_mode_requires_source(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("agent:\n  provider: codex\n", encoding="utf-8")  # no bench.sources
+    result = runner.invoke(app, ["generate", "-c", str(config_file), "--mode", "bench"])
+    assert result.exit_code == 1
+    assert "bench.sources" in result.output
+
+
+def test_generate_bench_refuses_to_mix_with_prompts_output(tmp_path: Path):
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "some-trace.jsonl").write_text('{"messages": []}\n', encoding="utf-8")  # prompts data
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        f"agent:\n  provider: pi\nbench:\n  sources:\n    - {{type: harbor, source: {tmp_path}/tasks}}\noutput:\n  traces_dir: {output}\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["generate", "-c", str(config_file), "--mode", "bench"])
+    assert result.exit_code == 1
+    assert "already contains prompts-mode data" in " ".join(result.output.split())
+
+
+def test_generate_prompts_refuses_to_mix_with_bench_output(tmp_path: Path):
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "bench-add-bug.jsonl").write_text('{"messages": []}\n', encoding="utf-8")  # bench data
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        f"agent:\n  provider: chat\nprompts:\n  - hello\noutput:\n  traces_dir: {output}\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["generate", "-c", str(config_file)])
+    assert result.exit_code == 1
+    assert "already contains bench-mode data" in " ".join(result.output.split())
+
+
+def test_existing_dataset_modes_classifies_rows(tmp_path: Path):
+    from teich.cli import _existing_dataset_modes
+
+    (tmp_path / "bench-x.jsonl").write_text('{"messages": []}\n', encoding="utf-8")
+    (tmp_path / "organic.jsonl").write_text('{"messages": []}\n', encoding="utf-8")
+    (tmp_path / "passed").mkdir()
+    (tmp_path / "passed" / "routed.jsonl").write_text('{"messages": []}\n', encoding="utf-8")
+    # Intermediates / empties must not count as dataset rows (a nested `bench` dir is excluded
+    # by name; normally bench_dir is a sibling of output and never under traces_dir at all).
+    (tmp_path / "bench" / "sessions").mkdir(parents=True)
+    (tmp_path / "bench" / "sessions" / "pi.jsonl").write_text('{"type":"session"}\n', encoding="utf-8")
+    (tmp_path / "empty.jsonl").write_text("", encoding="utf-8")
+    assert _existing_dataset_modes(tmp_path) == {"bench", "prompts"}
+
+
 def test_convert_command_writes_openai_style_training_jsonl(tmp_path: Path):
     traces_dir = tmp_path / "traces"
     traces_dir.mkdir()
@@ -465,7 +524,7 @@ api:
             folder_path=str(output_dir),
             repo_type="dataset",
             private=True,
-            ignore_patterns=["partials/**", "failures/**", "README.md", "tools.json"],
+            ignore_patterns=["partials/**", "failures/**", "bench/**", "README.md", "tools.json"],
         )
         mock_api.upload_folder.assert_called_once_with(
             folder_path=str(output_dir),
@@ -473,7 +532,7 @@ api:
             repo_type="dataset",
             commit_message="Upload teich dataset metadata",
             allow_patterns=["README.md"],
-            ignore_patterns=["partials/**", "failures/**"],
+            ignore_patterns=["partials/**", "failures/**", "bench/**"],
         )
 
 
@@ -621,7 +680,7 @@ api:
             folder_path=str(output_dir),
             repo_type="dataset",
             private=False,
-            ignore_patterns=["partials/**", "failures/**", "README.md", "tools.json"],
+            ignore_patterns=["partials/**", "failures/**", "bench/**", "README.md", "tools.json"],
         )
         mock_api.upload_folder.assert_called_once_with(
             folder_path=str(output_dir),
@@ -629,7 +688,7 @@ api:
             repo_type="dataset",
             commit_message="Upload teich dataset metadata",
             allow_patterns=["README.md"],
-            ignore_patterns=["partials/**", "failures/**"],
+            ignore_patterns=["partials/**", "failures/**", "bench/**"],
         )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,6 +202,25 @@ def test_config_bench_source_resolves_relative_to_config_dir(tmp_path: Path, mon
     assert Config.from_yaml(config_file).bench.sources[0].source == "terminal-bench@2.0"
 
 
+def test_config_bench_source_resolves_bare_relative_local_path(tmp_path: Path, monkeypatch):
+    """A bare relative bench source that exists beside the config (data/tasks) resolves against the
+    config dir too; a registry/HF spec with no matching local path is left untouched."""
+    project = tmp_path / "project"
+    (project / "data" / "tasks").mkdir(parents=True)
+    config_file = project / "config.yaml"
+    config_file.write_text(
+        "bench:\n  sources:\n"
+        "    - { type: harbor, source: data/tasks }\n"
+        "    - { type: swe-bench, source: SWE-bench/SWE-bench_Verified }\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)  # not the config dir
+
+    sources = Config.from_yaml(config_file).bench.sources
+    assert sources[0].source == str((project / "data" / "tasks").resolve())  # bare local resolved
+    assert sources[1].source == "SWE-bench/SWE-bench_Verified"  # HF id untouched
+
+
 def test_config_prompts_file(tmp_path: Path):
     """Test loading structured prompts from CSV file."""
     prompts_file = tmp_path / "prompts.csv"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -162,6 +162,24 @@ def test_config_generates_chat_dataset_tags():
     assert config.get_dataset_tags() == ["conversational", "distillation", "teich", "gpt-4.1-mini"]
 
 
+def test_config_readme_template_resolves_relative_to_config_dir(tmp_path: Path, monkeypatch):
+    """A relative output.readme_template resolves against the config file, like prompts_file —
+    not the process CWD, so `teich -c project/config.yaml` works from another directory."""
+    project = tmp_path / "project"
+    project.mkdir()
+    template = project / "card.md.j2"
+    template.write_text("# {{ pretty_name }}\n", encoding="utf-8")
+    config_file = project / "config.yaml"
+    config_file.write_text("output:\n  readme_template: card.md.j2\n", encoding="utf-8")
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)  # load from a different working directory
+
+    config = Config.from_yaml(config_file)
+    assert config.output.readme_template == template.resolve()
+
+
 def test_config_prompts_file(tmp_path: Path):
     """Test loading structured prompts from CSV file."""
     prompts_file = tmp_path / "prompts.csv"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,6 +180,28 @@ def test_config_readme_template_resolves_relative_to_config_dir(tmp_path: Path, 
     assert config.output.readme_template == template.resolve()
 
 
+def test_config_bench_source_resolves_relative_to_config_dir(tmp_path: Path, monkeypatch):
+    """A relative *local* bench source (./local-tasks) resolves against the config file, not CWD;
+    a registry spec (name@version) is left untouched."""
+    project = tmp_path / "project"
+    (project / "local-tasks").mkdir(parents=True)
+    config_file = project / "config.yaml"
+    config_file.write_text(
+        "bench:\n  sources:\n    - { type: harbor, source: ./local-tasks }\n", encoding="utf-8"
+    )
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)  # load from a different working directory
+
+    config = Config.from_yaml(config_file)
+    assert config.bench.sources[0].source == str((project / "local-tasks").resolve())
+
+    config_file.write_text(
+        "bench:\n  sources:\n    - { type: harbor, source: terminal-bench@2.0 }\n", encoding="utf-8"
+    )
+    assert Config.from_yaml(config_file).bench.sources[0].source == "terminal-bench@2.0"
+
+
 def test_config_prompts_file(tmp_path: Path):
     """Test loading structured prompts from CSV file."""
     prompts_file = tmp_path / "prompts.csv"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2875,6 +2875,20 @@ def test_convert_pi_trace_uses_thinking_blocks_and_tool_results(tmp_path: Path):
     assert bash_tool["function"]["parameters"]["properties"]["command"] == {"type": "string"}
 
 
+def _write_structured_trace(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}], "prompt": "hi"}
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+
+def test_convert_without_sidecar_has_no_reward(tmp_path: Path):
+    out = tmp_path / "output"
+    _write_structured_trace(out / "codex-z.jsonl")
+    rows = convert_traces_to_training_data(out)
+    assert "reward" not in rows[0]
+    assert "passed" not in rows[0]
+
+
 def test_codex_skips_injected_runtime_context(tmp_path: Path):
     """Codex injects <environment_context>/<user_instructions> as leading user
     messages; they must not become the prompt (which also breaks --resume)."""

--- a/tests/test_extract_anonymize_cli.py
+++ b/tests/test_extract_anonymize_cli.py
@@ -1512,7 +1512,7 @@ def test_extract_can_upload_staged_anonymized_output_to_huggingface(tmp_path: Pa
         folder_path=str(output_dir),
         repo_type="dataset",
         private=False,
-        ignore_patterns=["partials/**", "failures/**", "README.md", "tools.json"],
+        ignore_patterns=["partials/**", "failures/**", "bench/**", "README.md", "tools.json"],
     )
     mock_api.upload_folder.assert_called_once_with(
         folder_path=str(output_dir),
@@ -1520,11 +1520,11 @@ def test_extract_can_upload_staged_anonymized_output_to_huggingface(tmp_path: Pa
         repo_type="dataset",
         commit_message="Upload teich dataset metadata",
         allow_patterns=["README.md"],
-        ignore_patterns=["partials/**", "failures/**"],
+        ignore_patterns=["partials/**", "failures/**", "bench/**"],
     )
     readme = (output_dir / "README.md").read_text(encoding="utf-8")
     assert "armand0e/fable-traces" in readme
-    assert 'path: "**/*.jsonl"' in readme
+    assert 'path: "*.jsonl"' in readme  # top-level glob (excludes non-data subdirs)
     assert '- "codex"' in readme
     assert '- "pi"' not in readme
     assert '- "fable-5"' not in readme

--- a/tests/test_swebench.py
+++ b/tests/test_swebench.py
@@ -129,13 +129,21 @@ def test_tasks_rejects_langfuse_enabled():
 def test_agent_layer_for_known_providers():
     assert _agent_layer(_cfg("pi")).provider == "pi"
     assert _agent_layer(_cfg("codex")).provider == "codex"
-    # claude alias maps to claude-code
-    assert _agent_layer(_cfg("claude")).provider == "claude-code"
+    # claude alias maps to claude-code (needs an anthropic project, see the guard test below)
+    assert _agent_layer(_cfg("claude", api={"provider": "anthropic"})).provider == "claude-code"
 
 
 def test_agent_layer_rejects_unsupported_provider():
     with pytest.raises(RuntimeError, match="does not support agent provider 'chat'"):
         _agent_layer(_cfg("chat"))
+
+
+def test_agent_layer_rejects_claude_code_without_anthropic_provider():
+    # claude-code runs the Anthropic `claude` CLI; a non-anthropic project has no usable Claude
+    # creds in the container, so fail fast rather than emit empty traces.
+    with pytest.raises(RuntimeError, match="needs an anthropic-provider config"):
+        _agent_layer(_cfg("claude", api={"provider": "openrouter", "api_key": "sk-or"}))
+    assert _agent_layer(_cfg("claude", api={"provider": "anthropic", "api_key": "sk-ant"})).provider == "claude-code"
 
 
 def test_auth_env_openrouter_sets_both_keys():

--- a/tests/test_swebench.py
+++ b/tests/test_swebench.py
@@ -1,0 +1,264 @@
+"""Unit tests for the swe-bench bench backend (the Docker-free surface).
+
+The agent-run + grading seams need real Docker + the swebench package and are covered by an
+opt-in integration pass; here we test dataset loading, the Dockerfile render, the per-provider
+agent recipes, auth env, reward mapping, registration, and the install-hint guard.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from teich.bench.backends import get_backend
+from teich.bench.backends.swebench import (
+    SweBenchBackend,
+    _agent_layer,
+    _auth_env,
+    _load_instances,
+    _model_name,
+    _rewards_from_report,
+    _run_command,
+    render_agent_dockerfile,
+)
+from teich.config import BenchSource, Config
+
+
+def _cfg(provider="pi", api=None):
+    return Config(agent={"provider": provider}, api=api or {})
+
+
+# --------------------------------------------------------------------------- registration
+
+
+def test_get_backend_returns_swebench():
+    backend = get_backend("swe-bench")
+    assert isinstance(backend, SweBenchBackend)
+    assert backend.type == "swe-bench"
+
+
+def test_require_hint_without_swebench():
+    try:
+        import swebench  # noqa: F401
+
+        pytest.skip("swebench is installed; the missing-extra path can't be exercised")
+    except ImportError:
+        pass
+    with pytest.raises(RuntimeError, match=r"teich\[swe\]"):
+        SweBenchBackend().require()
+
+
+# --------------------------------------------------------------------------- dataset
+
+
+def _inject_fake_swebench(monkeypatch, loader):
+    swebench = types.ModuleType("swebench")
+    harness = types.ModuleType("swebench.harness")
+    utils = types.ModuleType("swebench.harness.utils")
+    utils.load_swebench_dataset = loader
+    monkeypatch.setitem(sys.modules, "swebench", swebench)
+    monkeypatch.setitem(sys.modules, "swebench.harness", harness)
+    monkeypatch.setitem(sys.modules, "swebench.harness.utils", utils)
+
+
+def test_load_instances_passes_split_and_ids(monkeypatch):
+    seen = {}
+
+    def loader(name, split, instance_ids):
+        seen.update(name=name, split=split, instance_ids=instance_ids)
+        return [{"instance_id": "django__django-1", "problem_statement": "fix it"}]
+
+    _inject_fake_swebench(monkeypatch, loader)
+    source = BenchSource(
+        type="swe-bench", source="SWE-bench/SWE-bench_Lite", split="dev", instances=["django__django-1"]
+    )
+    out = _load_instances(source)
+
+    assert out == [{"instance_id": "django__django-1", "problem_statement": "fix it"}]
+    assert seen == {"name": "SWE-bench/SWE-bench_Lite", "split": "dev", "instance_ids": ["django__django-1"]}
+
+
+def test_load_instances_defaults_split_to_test(monkeypatch):
+    seen = {}
+
+    def loader(name, split, instance_ids):
+        seen.update(split=split, instance_ids=instance_ids)
+        return []
+
+    _inject_fake_swebench(monkeypatch, loader)
+    _load_instances(BenchSource(type="swe-bench", source="x.jsonl"))
+    assert seen == {"split": "test", "instance_ids": None}
+
+
+def test_load_instances_wraps_errors(monkeypatch):
+    def loader(name, split, instance_ids):
+        raise KeyError("nope")
+
+    _inject_fake_swebench(monkeypatch, loader)
+    with pytest.raises(RuntimeError, match="Failed to load swe-bench dataset"):
+        _load_instances(BenchSource(type="swe-bench", source="bad"))
+
+
+def test_tasks_maps_instances_to_bench_tasks(monkeypatch):
+    import teich.bench.backends.swebench as mod
+
+    instances = [{"instance_id": "a__b-1"}, {"instance_id": "a__b-2"}]
+    monkeypatch.setattr(mod, "_load_instances", lambda source: instances)
+    tasks = SweBenchBackend().tasks(_cfg(), BenchSource(type="swe-bench", source="ds"))
+
+    assert [t.id for t in tasks] == ["a__b-1", "a__b-2"]
+    assert tasks[0].raw is instances[0]
+
+
+def test_tasks_rejects_langfuse_enabled():
+    # swe-bench doesn't wire Langfuse into the agent container, so it fails loudly rather than
+    # silently no-op. The guard fires before any dataset/Docker work, so no mocks are needed.
+    cfg = Config(agent={
+        "provider": "pi",
+        "langfuse": {"enabled": True, "public_key": "pk", "secret_key": "sk", "base_url": "https://lf"},
+    })
+    with pytest.raises(RuntimeError, match="does not support Langfuse"):
+        SweBenchBackend().tasks(cfg, BenchSource(type="swe-bench", source="ds"))
+
+
+# --------------------------------------------------------------------------- agent layer
+
+
+def test_agent_layer_for_known_providers():
+    assert _agent_layer(_cfg("pi")).provider == "pi"
+    assert _agent_layer(_cfg("codex")).provider == "codex"
+    # claude alias maps to claude-code
+    assert _agent_layer(_cfg("claude")).provider == "claude-code"
+
+
+def test_agent_layer_rejects_unsupported_provider():
+    with pytest.raises(RuntimeError, match="does not support agent provider 'chat'"):
+        _agent_layer(_cfg("chat"))
+
+
+def test_auth_env_openrouter_sets_both_keys():
+    cfg = _cfg("pi", api={"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "sk-or"})
+    env = _auth_env(cfg)
+    assert env["OPENAI_API_KEY"] == "sk-or"
+    assert env["OPENROUTER_API_KEY"] == "sk-or"
+    assert env["OPENAI_BASE_URL"] == "https://openrouter.ai/api/v1"
+
+
+def test_auth_env_openai_only_sets_openai_key():
+    cfg = _cfg("codex", api={"provider": "openai", "api_key": "sk-oai"})
+    env = _auth_env(cfg)
+    assert env["OPENAI_API_KEY"] == "sk-oai"
+    assert "OPENROUTER_API_KEY" not in env
+
+
+def test_auth_env_anthropic_sets_anthropic_key_only():
+    # The anthropic key must not be shadowed under OPENAI_API_KEY (would break OpenAI agents).
+    cfg = _cfg("claude", api={"provider": "anthropic", "api_key": "sk-ant"})
+    env = _auth_env(cfg)
+    assert env["ANTHROPIC_API_KEY"] == "sk-ant"
+    assert "OPENAI_API_KEY" not in env
+    assert "OPENROUTER_API_KEY" not in env
+
+
+# --------------------------------------------------------------------------- run command (model)
+
+
+def test_run_command_pins_configured_model():
+    cfg = Config(agent={"provider": "codex"}, model={"model": "gpt-5-codex"},
+                 api={"provider": "openai", "api_key": "sk"})
+    assert _run_command(cfg, _agent_layer(cfg)).endswith("--model gpt-5-codex")
+
+
+def test_run_command_pi_prefixes_provider():
+    cfg = Config(agent={"provider": "pi"}, model={"model": "z-ai/glm-5.2"},
+                 api={"provider": "openrouter"})
+    assert _run_command(cfg, _agent_layer(cfg)).endswith("--model openrouter/z-ai/glm-5.2")
+
+
+def test_run_command_no_model_is_unchanged():
+    # model.model defaults to a non-empty value, so the no-flag path needs an explicit empty model.
+    cfg = Config(agent={"provider": "codex"}, model={"model": ""})
+    layer = _agent_layer(cfg)
+    assert _model_name(cfg) == ""
+    assert _run_command(cfg, layer) == layer.run
+
+
+def test_ensure_instance_image_pull_bounds_timeout(monkeypatch):
+    # The remote-image pull must be bounded by the run timeout, not block forever.
+    import teich.bench.backends.swebench as mod
+
+    calls = []
+
+    class _CP:
+        stdout = ""  # empty -> the image isn't present locally -> take the pull path
+
+    def fake_docker(args, *, timeout=None, check=True):
+        calls.append((args, timeout))
+        return _CP()
+
+    monkeypatch.setattr(mod, "_docker", fake_docker)
+    spec = types.SimpleNamespace(instance_image_key="swebench/x:latest")
+    mod._ensure_instance_image(spec, namespace="swebench", timeout=42)
+    pull_timeout = next(t for a, t in calls if a[0] == "pull")
+    assert pull_timeout == 42
+
+
+# --------------------------------------------------------------------------- dockerfile render
+
+
+def test_render_dockerfile_from_instance_image_with_agent():
+    df = render_agent_dockerfile("swebench/sweb.eval.x86_64.django__django-1:latest", _agent_layer(_cfg("pi")))
+    lines = df.splitlines()
+    # The buildkit syntax directive must be the very first line, FROM the next directive.
+    assert lines[0] == "# syntax=docker/dockerfile:1"
+    directives = [ln for ln in lines if ln.strip() and not ln.startswith("#")]
+    assert directives[0] == "FROM swebench/sweb.eval.x86_64.django__django-1:latest"
+    assert "npm install -g @mariozechner/pi-coding-agent" in df
+    assert "WORKDIR /testbed" in df
+    assert "deb.nodesource.com" in df  # node runtime layer
+    assert "Langfuse" not in df  # off by default
+
+
+def test_render_dockerfile_includes_langfuse_block_when_enabled():
+    layer = _agent_layer(_cfg("codex"))
+    df = render_agent_dockerfile("base:img", layer, langfuse=True, langfuse_install="RUN echo lf")
+    assert "Langfuse" in df
+    assert "RUN echo lf" in df
+
+
+# --------------------------------------------------------------------------- rewards
+
+
+def test_rewards_resolved():
+    rewards = _rewards_from_report(
+        {
+            "resolved": True,
+            "patch_successfully_applied": True,
+            "tests_status": {
+                "FAIL_TO_PASS": {"success": ["t1", "t2"], "failure": []},
+                "PASS_TO_PASS": {"success": ["t3"], "failure": ["t4"]},
+            },
+        }
+    )
+    assert rewards["reward"] == 1.0
+    assert rewards["resolved"] == 1.0
+    assert rewards["patch_applied"] == 1.0
+    assert rewards["fail_to_pass"] == 1.0
+    assert rewards["pass_to_pass"] == 0.5
+
+
+def test_rewards_unresolved_routes_to_failed():
+    from teich.bench.backends import base
+
+    rewards = _rewards_from_report({"resolved": False, "patch_successfully_applied": False})
+    assert rewards["reward"] == 0.0
+    assert base.route_split(base.primary_score(rewards)) == "failed"
+
+
+def test_rewards_resolved_routes_to_passed():
+    from teich.bench.backends import base
+
+    rewards = _rewards_from_report({"resolved": True, "patch_successfully_applied": True})
+    assert base.route_split(base.primary_score(rewards)) == "passed"

--- a/tests/test_trace_readme.py
+++ b/tests/test_trace_readme.py
@@ -430,6 +430,22 @@ def test_reward_stats_counts_borderline_bench_tasks(tmp_path: Path):
     assert "3 of 3 carry an explicit numeric score" in readme
 
 
+def test_card_data_files_exclude_custom_failures_dir(tmp_path: Path):
+    # A custom output.failures_dir located under traces_dir (basename not in the reserved set)
+    # must not be advertised as a train split — those are failed/interrupted runs, ignored on
+    # upload — while a real data-bearing subdir still is.
+    (tmp_path / "failed-runs").mkdir()
+    _write_structured_row(tmp_path / "failed-runs" / "bad.jsonl")
+    (tmp_path / "proj").mkdir()
+    _write_structured_row(tmp_path / "proj" / "good.jsonl")
+
+    readme = write_traces_readme(
+        tmp_path, pretty_name="X", tags=["agent-traces"], excluded_dirs=[tmp_path / "failed-runs"]
+    ).read_text(encoding="utf-8")
+    assert 'path: "proj/**/*.jsonl"' in readme  # real nested data advertised
+    assert "failed-runs" not in readme  # custom failures dir not advertised
+
+
 def test_readme_has_no_reward_section_without_verification(tmp_path: Path):
     _write_structured_row(tmp_path / "plain.jsonl")
     readme_path = write_traces_readme(tmp_path, pretty_name="Plain Traces", tags=["agent-traces"])

--- a/tests/test_trace_readme.py
+++ b/tests/test_trace_readme.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 import json
 
-from teich.trace_readme import README_INLINE_TOOLS_MAX_CHARS, build_traces_readme, write_traces_readme
+import pytest
+
+from teich.trace_readme import (
+    README_INLINE_TOOLS_MAX_CHARS,
+    build_traces_readme,
+    size_category,
+    write_traces_readme,
+)
 
 
 def test_build_traces_readme_includes_model_and_references_tools(tmp_path: Path):
@@ -322,3 +329,223 @@ def test_write_traces_readme_uses_configured_tools_and_repo_id(tmp_path: Path):
     assert not (tmp_path / "tools.json").exists()
     assert '"name": "unobserved"' in readme
     assert '"description": "Available but not called"' in readme
+
+
+def _write_structured_row(path: Path, **extra) -> None:
+    row = {"prompt": "hi", "messages": [{"role": "assistant", "content": "ok"}], **extra}
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+
+def test_readme_is_reward_aware_from_verification_sidecars(tmp_path: Path):
+    # Two verified rows with sidecars; the card summarizes their pass/fail counts.
+    _write_structured_row(tmp_path / "task-a.jsonl", passed=True, reward=1.0)
+    _write_structured_row(tmp_path / "task-b.jsonl", passed=False, reward=0.0)
+    verification = tmp_path / "verification"
+    verification.mkdir()
+    (verification / "task-a.json").write_text(json.dumps({"passed": True}), encoding="utf-8")
+    (verification / "task-b.json").write_text(
+        json.dumps({"passed": False, "reward": 0.0}), encoding="utf-8"
+    )
+    # A harbor intermediate that must NOT be treated as data or pollute the card (a nested
+    # `bench` dir is excluded by name; by default bench_dir is a sibling, never under output).
+    bench_sessions = tmp_path / "bench" / "sessions" / "add-bug"
+    bench_sessions.mkdir(parents=True)
+    (bench_sessions / "pi.jsonl").write_text('{"type":"session","id":"x"}\n', encoding="utf-8")
+
+    readme_path = write_traces_readme(
+        tmp_path, pretty_name="Verifiable Traces", tags=["agent-traces"]
+    )
+    readme = readme_path.read_text(encoding="utf-8")
+    assert "## Reward labels" in readme
+    assert '- "reward-labeled"' in readme
+    assert "Verified tasks: 2 (1 passed / 1 failed)." in readme
+    assert "1 of 2 carry an explicit numeric score" in readme  # task-b has reward 0.0
+    assert "Rows: 2" in readme  # the bench/ session file is excluded from the row count
+    # The train split is a top-level glob that excludes the nested bench/ session.
+    assert "- split: train" in readme
+    assert 'path: "*.jsonl"' in readme
+    assert "**/*.jsonl" not in readme  # top-level glob, not recursive
+    assert "bench/sessions/add-bug/pi.jsonl" not in readme
+
+
+def test_readme_has_no_reward_section_without_verification(tmp_path: Path):
+    _write_structured_row(tmp_path / "plain.jsonl")
+    readme_path = write_traces_readme(tmp_path, pretty_name="Plain Traces", tags=["agent-traces"])
+    readme = readme_path.read_text(encoding="utf-8")
+    assert "## Reward labels" not in readme
+    assert "reward-labeled" not in readme
+    # No routing folders -> single top-level train glob (not the recursive **/*.jsonl).
+    assert "- split: train" in readme and 'path: "*.jsonl"' in readme
+    assert "**/*.jsonl" not in readme
+
+
+def test_card_splits_reflect_routing_folders(tmp_path: Path):
+    for split in ("passed", "failed", "borderline"):
+        (tmp_path / split).mkdir()
+        _write_structured_row(tmp_path / split / f"bench-{split}.jsonl")
+    readme = write_traces_readme(tmp_path, pretty_name="Bench", tags=["agent-traces"]).read_text(encoding="utf-8")
+    for split in ("passed", "failed", "borderline"):
+        assert f"- split: {split}" in readme
+        assert f'path: "{split}/*.jsonl"' in readme
+    assert "split: train" not in readme
+    assert '- "reward-labeled"' in readme  # routed datasets are reward-labeled
+
+
+def test_card_omits_empty_routing_splits(tmp_path: Path):
+    # Only passed/ has files -> only a passed split is declared (no empty failed/borderline).
+    (tmp_path / "passed").mkdir()
+    _write_structured_row(tmp_path / "passed" / "bench-a.jsonl")
+    readme = write_traces_readme(tmp_path, pretty_name="Bench", tags=["x"]).read_text(encoding="utf-8")
+    assert "- split: passed" in readme
+    assert "- split: failed" not in readme and "- split: borderline" not in readme
+
+
+# Golden byte-for-byte lock for the Jinja-rendered card. The body below is identical to the
+# pre-refactor (hand-assembled) build_traces_readme output; the only structural addition is the
+# auto-populated ``size_categories`` block (always-on now). Any unintended drift in the template
+# or context wiring will fail this exact-equality check.
+_GOLDEN_CHAT_CARD = '''---
+pretty_name: "Chat Dataset"
+task_categories:
+- text-generation
+tags:
+- "chat"
+configs:
+- config_name: default
+  data_files:
+  - split: train
+    path: "*.jsonl"
+size_categories:
+- n<1K
+---
+
+This dataset was generated using [teich](https://github.com/TeichAI/teich) by [TeichAI](https://huggingface.co/TeichAI) <img src="https://cdn-avatars.huggingface.co/v1/production/uploads/6837935ac3b7ffe0d2559ce9/-AxyvV4wfUY8uo87kNKkK.png" width="20" height="20" style="display: inline-block; vertical-align: middle; margin: 0 3px;">
+
+# Chat Dataset
+
+This directory contains newline-delimited JSON training examples generated by teich.
+
+Rows: 1
+
+Model metadata: `gpt-4.1-mini`
+
+## Format
+
+Each file is newline-delimited JSON where every line is already a training example.
+Chat-only datasets include `messages` plus convenience fields like optional `system`, `prompt`, `follow_up_prompts`, `thinking`, `response`, and `responses`.
+Tool datasets can include the same normalized `messages` structure together with a `tools` field.
+
+## Example
+
+```json
+{"messages": [{"role": "system", "content": "You are a helpful assistant", "thinking": null}, {"role": "user", "content": "Hello", "thinking": null}, {"role": "assistant", "content": "Hi!", "thinking": "I should greet the user."}], "system": "You are a helpful assistant", "prompt": "Hello", "thinking": "I should greet the user.", "response": "Hi!", "model": "gpt-4.1-mini"}
+```
+
+## Training
+
+Use this dataset as `username/repo` with Teich's data preparation and training utilities.
+If you do not want Teich to handle chat-template formatting or masking, run `teich convert` to write standalone OpenAI-style JSONL rows with `prompt`, `messages`, `tools`, and `metadata`.
+Training setup details evolve over time, so the maintained guide lives in the [Teich training docs](https://github.com/TeichAI/teich/blob/main/docs/training.md).
+For loading, mixing, converting, and validating Teich datasets, see [Preparing Data](https://github.com/TeichAI/teich/blob/main/docs/prepare-data.md).
+'''
+
+
+def test_rendered_card_matches_golden_byte_for_byte(tmp_path: Path):
+    trace_file = tmp_path / "chat.jsonl"
+    trace_file.write_text(
+        '{"messages":[{"role":"system","content":"You are a helpful assistant","thinking":null},'
+        '{"role":"user","content":"Hello","thinking":null},'
+        '{"role":"assistant","content":"Hi!","thinking":"I should greet the user."}],'
+        '"system":"You are a helpful assistant","prompt":"Hello",'
+        '"thinking":"I should greet the user.","response":"Hi!","model":"gpt-4.1-mini"}\n',
+        encoding="utf-8",
+    )
+    readme = write_traces_readme(
+        tmp_path, pretty_name="Chat Dataset", tags=["chat"], model_id="gpt-4.1-mini"
+    ).read_text(encoding="utf-8")
+    assert readme == _GOLDEN_CHAT_CARD
+
+
+@pytest.mark.parametrize(
+    "row_count, expected",
+    [
+        (0, None),
+        (-5, None),
+        (999, "n<1K"),
+        (1000, "1K<n<10K"),
+        (9999, "1K<n<10K"),
+        (10_000, "10K<n<100K"),
+        (999_999, "100K<n<1M"),
+        (1_000_000, "1M<n<10M"),
+        (1_000_000_000_000, "n>1T"),
+        (5_000_000_000_000, "n>1T"),
+    ],
+)
+def test_size_category_bucket_boundaries(row_count, expected):
+    assert size_category(row_count) == expected
+
+
+def test_card_includes_license_when_set(tmp_path: Path):
+    _write_structured_row(tmp_path / "row.jsonl")
+    readme = write_traces_readme(
+        tmp_path, pretty_name="Licensed", tags=["x"], license="apache-2.0"
+    ).read_text(encoding="utf-8")
+    assert "license: apache-2.0\n" in readme
+    # Placed inside the frontmatter block, before the closing fence.
+    frontmatter = readme.split("---", 2)[1]
+    assert "license: apache-2.0" in frontmatter
+
+
+def test_card_omits_license_when_unset(tmp_path: Path):
+    _write_structured_row(tmp_path / "row.jsonl")
+    readme = write_traces_readme(tmp_path, pretty_name="Unlicensed", tags=["x"]).read_text(
+        encoding="utf-8"
+    )
+    assert "license:" not in readme
+
+
+def test_card_extra_keys_appear_and_reserved_keys_dropped(tmp_path: Path):
+    _write_structured_row(tmp_path / "row.jsonl")
+    readme = write_traces_readme(
+        tmp_path,
+        pretty_name="Extra",
+        tags=["x"],
+        card_extra={
+            "annotations_creators": ["machine-generated"],
+            "language": ["en"],
+            # Reserved keys the card owns must be dropped, not allowed to shadow.
+            "tags": ["should-not-appear"],
+            "pretty_name": "should-not-appear",
+            "size_categories": ["should-not-appear"],
+            "license": "should-not-appear",
+        },
+    ).read_text(encoding="utf-8")
+    frontmatter = readme.split("---", 2)[1]
+    assert "annotations_creators:" in frontmatter
+    assert "machine-generated" in frontmatter
+    assert "language:" in frontmatter
+    assert "should-not-appear" not in readme
+
+
+def test_card_extra_empty_dict_adds_no_lines(tmp_path: Path):
+    _write_structured_row(tmp_path / "row.jsonl")
+    baseline = write_traces_readme(tmp_path, pretty_name="Plain", tags=["x"]).read_text(
+        encoding="utf-8"
+    )
+    with_empty = write_traces_readme(
+        tmp_path, pretty_name="Plain", tags=["x"], card_extra={}
+    ).read_text(encoding="utf-8")
+    assert baseline == with_empty
+
+
+def test_custom_readme_template_override_renders(tmp_path: Path):
+    template = tmp_path / "card.md.j2"
+    template.write_text(
+        "---\npretty_name: \"{{ pretty_name }}\"\n---\nCustom card for {{ pretty_name }}, rows {{ rows_line }}.\n",
+        encoding="utf-8",
+    )
+    _write_structured_row(tmp_path / "row.jsonl")
+    readme = write_traces_readme(
+        tmp_path, pretty_name="Override", tags=["x"], readme_template=template
+    ).read_text(encoding="utf-8")
+    assert readme == '---\npretty_name: "Override"\n---\nCustom card for Override, rows Rows: 1.\n'

--- a/tests/test_trace_readme.py
+++ b/tests/test_trace_readme.py
@@ -411,6 +411,25 @@ def test_reward_stats_from_bench_metadata_sidecars(tmp_path: Path):
     assert "2 of 2 carry an explicit numeric score" in readme
 
 
+def test_reward_stats_counts_borderline_bench_tasks(tmp_path: Path):
+    # A partial score (0<r<1) routes to borderline with a numeric reward; it must be counted as a
+    # verified task, not dropped (an all-borderline run must still show the reward section).
+    rows = (("passed", "bench-a", 1.0), ("failed", "bench-b", 0.0), ("borderline", "bench-c", 0.6))
+    metadata = tmp_path / "metadata"
+    metadata.mkdir()
+    for split, stem, reward in rows:
+        (tmp_path / split).mkdir(exist_ok=True)
+        _write_structured_row(tmp_path / split / f"{stem}.jsonl")
+        (metadata / f"{stem}.json").write_text(
+            json.dumps({"split": split, "reward": reward}), encoding="utf-8"
+        )
+    readme = write_traces_readme(tmp_path, pretty_name="Bench", tags=["agent-traces"]).read_text(
+        encoding="utf-8"
+    )
+    assert "Verified tasks: 3 (1 passed / 1 failed / 1 borderline)." in readme
+    assert "3 of 3 carry an explicit numeric score" in readme
+
+
 def test_readme_has_no_reward_section_without_verification(tmp_path: Path):
     _write_structured_row(tmp_path / "plain.jsonl")
     readme_path = write_traces_readme(tmp_path, pretty_name="Plain Traces", tags=["agent-traces"])

--- a/tests/test_trace_readme.py
+++ b/tests/test_trace_readme.py
@@ -368,6 +368,49 @@ def test_readme_is_reward_aware_from_verification_sidecars(tmp_path: Path):
     assert "bench/sessions/add-bug/pi.jsonl" not in readme
 
 
+def test_card_data_files_reach_nested_extractions(tmp_path: Path):
+    # Cursor extraction writes transcripts under nested project-relative dirs. A bare top-level
+    # `*.jsonl` would advertise an empty dataset while the card still counts these rows, so the
+    # HF data_files config must include a recursive glob for each data-bearing subdir.
+    nested = tmp_path / "c-Users-test-project" / "agent-transcripts" / "session-1"
+    nested.mkdir(parents=True)
+    _write_structured_row(nested / "session-1.jsonl")
+    # a non-data dir (excluded by name) must NOT be advertised
+    (tmp_path / "failures").mkdir()
+    _write_structured_row(tmp_path / "failures" / "oops.jsonl")
+
+    readme = write_traces_readme(tmp_path, pretty_name="Cursor Traces", tags=["agent-traces"]).read_text(
+        encoding="utf-8"
+    )
+    assert "- split: train" in readme
+    assert 'path: "*.jsonl"' in readme  # top-level files still advertised
+    assert 'path: "c-Users-test-project/**/*.jsonl"' in readme  # nested extraction reached
+    assert "failures/" not in readme  # non-data dir not advertised
+    assert "Rows: 1" in readme  # the nested row is counted (and now reachable)
+
+
+def test_reward_stats_from_bench_metadata_sidecars(tmp_path: Path):
+    # Bench harvest writes metadata/<stem>.json (split + numeric reward), not verification/.
+    # The card's reward summary must read those so bench datasets show pass/fail counts.
+    for split, stem in (("passed", "bench-ds-a"), ("failed", "bench-ds-b")):
+        (tmp_path / split).mkdir(exist_ok=True)
+        _write_structured_row(tmp_path / split / f"{stem}.jsonl")
+    metadata = tmp_path / "metadata"
+    metadata.mkdir()
+    (metadata / "bench-ds-a.json").write_text(
+        json.dumps({"task": "a", "split": "passed", "reward": 1.0}), encoding="utf-8"
+    )
+    (metadata / "bench-ds-b.json").write_text(
+        json.dumps({"task": "b", "split": "failed", "reward": 0.0}), encoding="utf-8"
+    )
+    readme = write_traces_readme(tmp_path, pretty_name="Bench", tags=["agent-traces"]).read_text(
+        encoding="utf-8"
+    )
+    assert "## Reward labels" in readme
+    assert "Verified tasks: 2 (1 passed / 1 failed)." in readme
+    assert "2 of 2 carry an explicit numeric score" in readme
+
+
 def test_readme_has_no_reward_section_without_verification(tmp_path: Path):
     _write_structured_row(tmp_path / "plain.jsonl")
     readme_path = write_traces_readme(tmp_path, pretty_name="Plain Traces", tags=["agent-traces"])

--- a/uv.lock
+++ b/uv.lock
@@ -5,9 +5,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
 
@@ -204,12 +207,215 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/af/473c241e41c142ea06ebef8d1f660fa6ff928fb97210e7bec8ee5974f8cd/cbor2-6.1.2.tar.gz", hash = "sha256:6b43037a66947dee5af0abb1a4c3a13b3abac5a4a3f32f9771efbbcd030fd909", size = 86760, upload-time = "2026-06-02T19:01:29.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/3f/37771defcae022510d640df8e420b7968c01804c084ff8cd2b9021c8873b/cbor2-6.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ffda338fe434d8d37e92e0d2e8f66432f0aa983f769dd2417f1eb6dfce634d3", size = 412096, upload-time = "2026-06-02T19:00:21.183Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ab/a10563c43a937a5fc0c5c52ee14f8380c7ba66634294759cc3dd3697d521/cbor2-6.1.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:715112c1087bc65f26d50ed4ffaaa214cbd398fbfb0d1a45f7edf555e77c7ca6", size = 457955, upload-time = "2026-06-02T19:00:22.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a9/443cb3f0b086cbb78e3df098bce6f8fb6cabc39b9ea5b46bca27b7adf4ad/cbor2-6.1.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:86b030a6accec1b4a58387e27edb656921c4b6d5d36d60f05d19915526233402", size = 468656, upload-time = "2026-06-02T19:00:24.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/2b2446767225078c023fd32523f84dceecb2a94e7ac7259b27d1527a5eac/cbor2-6.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:fe007e47f6edb828cc97af256ce3452f57431cb8841302c3c28543efc7c9e037", size = 523323, upload-time = "2026-06-02T19:00:25.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/cfe388abc06d59e8393a1a5fa260d5412b5a68963de0ef0e79f6395a3cb7/cbor2-6.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:95e3d99160f105b8b6bccb1033c9c14e8ca7c450d8999363882d87357313b78e", size = 534929, upload-time = "2026-06-02T19:00:27.61Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e8/8b454b8d405d9a66935b47bf5d9b045147bcf86f7747161598a32e5169ad/cbor2-6.1.2-cp310-cp310-win32.whl", hash = "sha256:464abc44b6863f888c9e263078e52395bddc03f20a3bd59f58fff581788fea51", size = 284490, upload-time = "2026-06-02T19:00:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3e/ecce89144cd820ba6f528debedff4948b6022996d3fcc4715e69f6acb483/cbor2-6.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:a3d1699de84d8aec4e9c6c3fdd450d86fac183a542733f0cac36a4317db2375a", size = 301090, upload-time = "2026-06-02T19:00:30.619Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cd/92f77e8bdfef427c6617cd4b02898e9d88861db8dcc973cc8b2c29a51582/cbor2-6.1.2-cp310-cp310-win_arm64.whl", hash = "sha256:925ebc6d26a0d3aa81377bdcfd8d44d166f4f6a5ee77467a9d6f3ed1487fc499", size = 292330, upload-time = "2026-06-02T19:00:31.946Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1e/687d7a712755c84a4b823ca79622dceef7ddfb0a3387b6ac1cad10835e07/cbor2-6.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6ce8f6d9e234bdf36b5300bf3da98fafc198b253f8dfe77747327806bdb37d97", size = 411738, upload-time = "2026-06-02T19:00:33.396Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d3/a96162ac244e074f9c188ffd29c086c51466e71c7c360189f6204900db3d/cbor2-6.1.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9f81ab0e74671b0ff9b7e30386e2ab8d40ee1049d13c1680b57ab1b1cd95c81a", size = 457945, upload-time = "2026-06-02T19:00:34.729Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f3/7fed7cee8456932d38e7b11d5034470ee9e91378d16f762c552e78df34fa/cbor2-6.1.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:5a429fc61db768c3b4739eb8532556eed86913ad64fe6ebbc1f3a646fb9a4f22", size = 468758, upload-time = "2026-06-02T19:00:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e9/bb31f04c5afa53eb55927da1399cc596d7e84e7053de7abf2c3aba0ea3a9/cbor2-6.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:511999bf3310c6641d3d15ee3853daa7ebd6ef3130bb0d63b9a7e2fd720a3714", size = 523169, upload-time = "2026-06-02T19:00:37.422Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7f/90faf18c280abb49428ed2e78f672ef0c7f6eb1b9b685bc4fe810f2e5e95/cbor2-6.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3099e678283efd2d3cabd6ddcb770da6e2102c0d265f98bca38aa4e720e247cf", size = 534885, upload-time = "2026-06-02T19:00:38.972Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8a/447aea5da80847bb17ca4718cd4909a2dc8dfe6f68ede4fe29f94b4ca12c/cbor2-6.1.2-cp311-cp311-win32.whl", hash = "sha256:0ef832ac8152ca76a69c184fe401329629b7dfd5fdddd713121bf1ff6d21660f", size = 284601, upload-time = "2026-06-02T19:00:40.426Z" },
+    { url = "https://files.pythonhosted.org/packages/55/95/6239187639a875eb83b924c16f4938d3d735c9c45474008c8b962bd55da2/cbor2-6.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:08cdc03d65e965aafd04c3bf9cb54b8cba55041756bd39d0ba6cd62bd060f959", size = 301284, upload-time = "2026-06-02T19:00:41.693Z" },
+    { url = "https://files.pythonhosted.org/packages/76/cb/e5f92271747a0331ca9151fac4098f8e245f1b09623ddff1258967a35b01/cbor2-6.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:0e2cfd25a395d454990d67148103107293c6506c3b0b15952a6e97f53d23deda", size = 292228, upload-time = "2026-06-02T19:00:43.27Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0c/a857b6ca032282b564cf25de18ad92fe0614e8b3fa3422eb10e32a873939/cbor2-6.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92b158d3ff9d9dce70eeb09786a6e518e3cb0ecb927fd23e9a0f7fc4b175c01a", size = 409592, upload-time = "2026-06-02T19:00:44.556Z" },
+    { url = "https://files.pythonhosted.org/packages/29/db/e0518153b3228159d9373f3b5785d7ea2d68898e27ee1bce7d03f0b5f7aa/cbor2-6.1.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d29a11044b07048e19f39a87fe8fea7ea865eb0ace50dc4c29513d52d40e2ddf", size = 454598, upload-time = "2026-06-02T19:00:45.784Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/62127b22edc6011ba55b76a28ab7c2219a45d01871a8199532e0978b26d1/cbor2-6.1.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a106f174eda34d8937a621c7f3e6044586cb209170cdc8da0ffbea89d1d6e385", size = 467380, upload-time = "2026-06-02T19:00:47.196Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/7992d8ec904c116ad547abb4960cc3fde695d5853c66596b1465d14d2f7b/cbor2-6.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ea16a25cc457a92879ff7a36cc50b587bddba09d8176bf1a94803eec5aa27eb", size = 521672, upload-time = "2026-06-02T19:00:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/80cc4be132a523f0c92fb4c71813577bb393abea9e27990ca74605e0e930/cbor2-6.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2652a94224980d47f2a3866dd35b1afe532ecdfaf91f8cfcec39a026c457a844", size = 534402, upload-time = "2026-06-02T19:00:50.064Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ea/99e466d8bef61a0775a1d8538ae6c9d95f4533fadc01f8f7814cb7ab80ad/cbor2-6.1.2-cp312-cp312-win32.whl", hash = "sha256:618666292900487db4a5abcade3150105c9c9fdd22576e6ff297c9a72eef0c6a", size = 283225, upload-time = "2026-06-02T19:00:51.406Z" },
+    { url = "https://files.pythonhosted.org/packages/14/13/e6a677bdc499e43049006cb54fe605b0f7aef621402d31354cc42ef293c9/cbor2-6.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:c61c0b2e2cee64497e6c62d1976bc212f62ac0cd2b5b903613610d79b8b06b60", size = 300844, upload-time = "2026-06-02T19:00:52.628Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4a/08bd8461f8e2e1ce1de5ae2768f2b7ca39a090e3156c1ee0d9b5fd86e70d/cbor2-6.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c871e7266ddc545b258e6f8e5300396985dc485d7ccf8bb4777385782f302153", size = 289040, upload-time = "2026-06-02T19:00:53.971Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/dc/bc045c8f36317e4e5f7a60d94b36833139909fc32e3a65f44bc61a36def0/cbor2-6.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f1aa38c422d87ea61849b2a823b10b64053fb4da8763f19ac78ea9a69d682b2a", size = 408846, upload-time = "2026-06-02T19:00:55.476Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/36/d66f5f0dd98ecbdcfc7da1fbd423f7b3782a27719f0062a560476f00b334/cbor2-6.1.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ff7d0bd8ff432832338a8d2430aee34f8a082342480ff537c0ba90e2b8ff7894", size = 454624, upload-time = "2026-06-02T19:00:56.744Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6b/4884b9cf03db14dc5007825d5d1bf8678a75c49d4268d8e0c1c6e9580104/cbor2-6.1.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:c1eedf3290d88a5f663bd8b4b8f0f0e2103d0594c293fa5f4e62e53100972309", size = 466585, upload-time = "2026-06-02T19:00:58.209Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/36a15beb3915f56a79d6e9213c6d40c0f5cb90cd3462923f555d78068847/cbor2-6.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3049b04bddf9a5a2d0e5bb25dccdaf4552fcaf607b404e249d4f78f010fcc7d0", size = 521678, upload-time = "2026-06-02T19:00:59.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3f/e899313371ebeb7a191d751de97ccd8242abc24bbc9d8e2c58e04475cfb0/cbor2-6.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:96eb687a62040401668f06a85de8f47361ef44574de1493899e0ec678109fc04", size = 534044, upload-time = "2026-06-02T19:01:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/1a872acdeb1ab9a884ec3460f73a43e02154dc20d8ccb627bbd60f4c0ea1/cbor2-6.1.2-cp313-cp313-win32.whl", hash = "sha256:03440b505882280023db1fedcee6844804e9968bb50f9eb4ff12aaf27777fcfe", size = 282328, upload-time = "2026-06-02T19:01:02.347Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/29721bc15d38889e7bec214ede2346ee15970bedcc5e6ce1fa30f21e9a4e/cbor2-6.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:d2c8da2c0f821827dcc9eb59a5c9351791a8aa3b389a2ea7ca64c4f97bcb94cf", size = 300313, upload-time = "2026-06-02T19:01:03.69Z" },
+    { url = "https://files.pythonhosted.org/packages/07/98/a13b424fb2f14fe332b57f71f479953b2f291a051f797d42ddab9fcd2027/cbor2-6.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:8e1478d3b980ddfcaf56e27cecbfe13057e0f67d5e8240fe8a398815acb9c4bf", size = 288725, upload-time = "2026-06-02T19:01:04.933Z" },
+    { url = "https://files.pythonhosted.org/packages/62/72/949bdc7422acd868a2355ae032561a104973fb5de284b36a237b85780dc9/cbor2-6.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b0b65314a0b18c47651e17792447171a858dd77e3f161c451ad850d63f8718a9", size = 407436, upload-time = "2026-06-02T19:01:06.259Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/5969f9263102d1c15aa370b39802e4a87b1d1703fdb51588daf38b5fbe7e/cbor2-6.1.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:8904deb2849bae40cea970e114398a19da371e1048ae1409e64f167a1205daf6", size = 453507, upload-time = "2026-06-02T19:01:07.795Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a5/227b785692a8374e3dbdf1fe76d1a9af48239855abd68a4111a1458fd81b/cbor2-6.1.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b29d58d8ce00535354d873df170a3e9f0f0a02af65d12102d2552e2129c65dc8", size = 464875, upload-time = "2026-06-02T19:01:09.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/48/a06527c3fbed4c32816abba4540e432fe9cd7e739a37fef0f205bd0f1e44/cbor2-6.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:27be1cc0abc42f154a48a315c92feb2bfb50397e51c70860460438ea172198a5", size = 519940, upload-time = "2026-06-02T19:01:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1b/0e3f0dac7140d4b94ffbcef765fa4cce0caa1d942060101149de998fa7be/cbor2-6.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b8d87fb8a33ff1971cb01511e74b044767cbba1ba536d3dc0b0c48f0d1b62237", size = 532612, upload-time = "2026-06-02T19:01:12.363Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2f/5af245e7667b65c6e4a714bb5d89c84de5573b857eba9137533d54bc2e4f/cbor2-6.1.2-cp314-cp314-win32.whl", hash = "sha256:72ba0ea913ca1a8d916867f1b7d414f140982d2873e5d92f8f51de437e08979e", size = 285886, upload-time = "2026-06-02T19:01:13.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0a/6303f3e19730450c5a82b97cd2c0ed54855f9108502041305b4c641116cd/cbor2-6.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:c02b7d94fe9914798a346a2f089f0f7f85be71d120d40080916d131fa0bd0442", size = 308808, upload-time = "2026-06-02T19:01:14.944Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/61/48f9c5545223dad9d2ea2061a76da739b4047a461297b621fc80ce0f65c0/cbor2-6.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:2af1309865000c401755fd4fdd5550f74ac34c3f79eb7db15f3956714769a5a9", size = 299522, upload-time = "2026-06-02T19:01:16.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2b/efcc6578b4e6142fb8ec9212c0dee5030345db2092f26aa960236067e717/cbor2-6.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9f26e08dd78ee77d103065543a65cfb838948fa8735180ad4d81d939950a1420", size = 402925, upload-time = "2026-06-02T19:01:17.979Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f6/58c86aa6246b3e7de473d8ff79ac8cc986e95cafe208899a70d6916012d7/cbor2-6.1.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:596e238f24bf9ede11a1ad08d2115fe78105ed6dda42ce1dd35872e7e91974fd", size = 446201, upload-time = "2026-06-02T19:01:19.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/12/3b90820583e9860e35cb5e91f3b2cd2ab1bbdf1c57fc63aa572952f5f75f/cbor2-6.1.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:08a62f69fe0f0ee1428d901423853b56bb5c775430f798401f8fac4b9affdecc", size = 460193, upload-time = "2026-06-02T19:01:20.876Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/88/c1e841ffb39a8e7163d7d432f7ea0e59b812c5134a449c75b6b8eb8aad08/cbor2-6.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6ca0080e4d8ab0d67c0518ac995d03151a1274b5c295c9e619fb6057c91ae49e", size = 511446, upload-time = "2026-06-02T19:01:22.18Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/f1ede587a388f127b9fc3d8ecb2f5d948654fed9fc7698f8b05fd90986bf/cbor2-6.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b44eb2f3ea1c8d9cb3e39c345204ec4d9489f8149b78eb5e058b13b14a8c7b07", size = 527683, upload-time = "2026-06-02T19:01:23.639Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/e3210ea45855a8d6173821f712a71a90d23dea0c134c4017c6f666a04fdf/cbor2-6.1.2-cp314-cp314t-win32.whl", hash = "sha256:f93179b4b1ba958b5c37b56969b8f07b4fcf44a83319f47559c59f28a1c564a4", size = 280419, upload-time = "2026-06-02T19:01:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/96/84/b555de26cc01108a72ed1df8eb7ca1d63495a3727045f0f93318dc5f99a8/cbor2-6.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:3c6c3d6598c268abf7068ae75b23b19f708e7a4aa294341b356deb65cb2664f1", size = 302514, upload-time = "2026-06-02T19:01:26.782Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6e/5556939414c0d2bffed7c7a53cf2b32181b55a795944d19835d513a7bc88/cbor2-6.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:8c2202fd1906f978bff3f97b21351815753dd9a8fcf4612a5113b6b257089059", size = 290058, upload-time = "2026-06-02T19:01:28.077Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "python_full_version >= '3.12' and implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/1b/7f73766c119a1344eb69e31890ede7c5825ce03d69a9d29292d1bd1cfa1b/chardet-7.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0c79b13c9908ac7dfe0a74116ebc9a0f28b2319d23c32f3dfcdfbe1279c7eaf", size = 874121, upload-time = "2026-04-13T21:32:47.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/02/b677c8203d34dad6c2af48287bb1f8c5dff63db2094636fbe634b555b7fb/chardet-7.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bba8bea1b28d927b3e99e47deafe53658d34497c0a891d95ff1ba8ff6663f01c", size = 856900, upload-time = "2026-04-13T21:32:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/4b/1361a485a999d97cac4c895e615326f69a639532a52ef365a468bd09bad1/chardet-7.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23163921dccf3103ce59540b0443c106d2c0a0ff2e0503e05196f5e6fdea453f", size = 876634, upload-time = "2026-04-13T21:32:50.238Z" },
+    { url = "https://files.pythonhosted.org/packages/87/23/e31c8ad33aa448f0845fd58af5fc22da1626407616d09df4973b2b34f477/chardet-7.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfb54563fe5f130da17c44c6a4e2e8052ba628e5ab4eab7ef8190f736f0f8f72", size = 886497, upload-time = "2026-04-13T21:32:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ef/ea4edec8c87f7e6eda02673acc68fe48725e564fc5a1865782efb53d5598/chardet-7.4.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3990fffcc6a6045f2234ab72752ad037e3b2d48c72037f244d42738db397eb75", size = 881061, upload-time = "2026-04-13T21:32:53.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/fc10600da98541777d720ad9e6bc040c0e0af1adb92e27142e35158957cb/chardet-7.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c7116b0452994734ccff35e154b44240090eb0f4f74b9106292668133557c175", size = 942533, upload-time = "2026-04-13T21:32:55.134Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/505c207f334d51e937cbaa27ff95776e16e2d120e13cbe491cd7b3a70b50/chardet-7.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:25a862cddc6a9ac07023e808aedd297115345fbaabc2690479481ddc0f980e09", size = 870747, upload-time = "2026-04-13T21:32:56.916Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4b/d3c79495dee4831b8bebca2790e72cb90f0c5849c940570a7c7e5b70b952/chardet-7.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7005c88da26fd95d8abb8acbe6281d833e9a9181b03cf49b4546c4555389bd97", size = 853210, upload-time = "2026-04-13T21:32:58.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/99/f6a822ad1bde25a4c38dc3e770485e78e0893dfd871cd6e18ed3ea3a795e/chardet-7.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc50f28bad067393cce0af9091052c3b8df7a23115afd8ba7b2e0947f0cef1f8", size = 873625, upload-time = "2026-04-13T21:32:59.606Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/10/31932775c94a86814f76b41c4a772b52abfb0e6125324f32c6da1196c297/chardet-7.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3da294de1a681097848ab58bd3f2771a674f8039d2d87a5538b28856b815e9", size = 883436, upload-time = "2026-04-13T21:33:01.351Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/63/0f43e3acf2c436fdb32a0f904aeb03a2904d2126eed34a042a194d235926/chardet-7.4.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:93c45e116dd51b66226a53ade3f9f635e870de5399b90e00ce45dcc311093bf4", size = 876589, upload-time = "2026-04-13T21:33:02.636Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a6/e9b8f8a3e99602792b01fa7d0a731737615ab56d8bfd0b52935a0ef88b85/chardet-7.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:ccc1f83ab4bcfb901cf39e0c4ba6bc6e726fc6264735f10e24ceb5cb47387578", size = 941866, upload-time = "2026-04-13T21:33:04.282Z" },
+    { url = "https://files.pythonhosted.org/packages/61/33/29de185079e6675c3f375546e30a559b7ddc75ce972f18d6e566cd9ea4eb/chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971", size = 874870, upload-time = "2026-04-13T21:33:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/4c5af01fd1a7506a1d5375403d68925eac70289229492db5aa68b58103d8/chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a", size = 854859, upload-time = "2026-04-13T21:33:07.381Z" },
+    { url = "https://files.pythonhosted.org/packages/36/21/edb36ad5dfa48d7f8eed97ab43931ecdaa8c15166c21b1d614967e49d681/chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235", size = 875032, upload-time = "2026-04-13T21:33:08.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/a32a241d861cf180853a11c8e5a67641cb1b2af13c3a5ccce83ec07e2c9f/chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb", size = 888283, upload-time = "2026-04-13T21:33:10.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/e1ee6a77abf3782c00e05b89c4d4328c8353bf9500661c4348df1dd68614/chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f", size = 879974, upload-time = "2026-04-13T21:33:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/32/60/fca69c534602a7ced04280c952a246ad1edde2a6ca3a164f65d32ac41fe7/chardet-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101", size = 943973, upload-time = "2026-04-13T21:33:12.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/79ac9b4db5bc87020c9dbc419125371d80882d1d197e9c4765ba8682b605/chardet-7.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9", size = 873769, upload-time = "2026-04-13T21:33:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/25bdec773905bff0ff6cf35ca73b17bd05593b4f87bd8c5fa43705f7167d/chardet-7.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a", size = 853991, upload-time = "2026-04-13T21:33:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/a29380ee0b215d23d77733b5ad60c5c0c7969650e080c667acdf9462040d/chardet-7.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357", size = 874024, upload-time = "2026-04-13T21:33:16.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b1/3338e121cbd4c8a126b8ccb1061170c2ce51a53f678c502793ea49c6fd6d/chardet-7.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d", size = 887410, upload-time = "2026-04-13T21:33:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1c/44a9a9e0c59c185a5d307ceaeee8768afa1558f0a24f7a4b5fa11b67586b/chardet-7.4.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb", size = 879269, upload-time = "2026-04-13T21:33:20.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/5d0e77ea774bd3224321c248880ea0c0379000ac5c2bb6d77609549de247/chardet-7.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131", size = 944155, upload-time = "2026-04-13T21:33:21.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
 ]
 
 [[package]]
@@ -318,6 +524,24 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.2.108"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "mcp", marker = "python_full_version >= '3.12'" },
+    { name = "sniffio", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/35/34b602015ebff64e5d39a0bb481679a4dd0a474d4c0afc5d3ac946b82af3/claude_agent_sdk-0.2.108.tar.gz", hash = "sha256:65bbb67593570d5752f596af71743ed9063e08116b847cd4cd3c15d86ee392b2", size = 255639, upload-time = "2026-06-23T21:17:17.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/98/796383c450f2680bcfd062dcdc816157e924f20118f985549943b97c2c11/claude_agent_sdk-0.2.108-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b9e79c68ac63a392227cb325b10b694549f1d361d0e69961e5a3d7ca794a910c", size = 63680678, upload-time = "2026-06-23T21:17:21.484Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ed/b7d4485ef0a57c6a9c28ad496e7bf89175f2d00e0a28b4c091d5ebbb670b/claude_agent_sdk-0.2.108-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:cdc416dc43faaf6e1ac0797c051c0b364c52cceb0190892f74e7373cfcfde714", size = 68264650, upload-time = "2026-06-23T21:17:26.028Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e7/04d252fc286228ff6fe79374886cb9866b95aaad8574a90efeb403c2761d/claude_agent_sdk-0.2.108-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:116402fd52e779394ac5c1493ae82996b29b91dff6594790746864563ab09601", size = 73497502, upload-time = "2026-06-23T21:17:31.447Z" },
+    { url = "https://files.pythonhosted.org/packages/29/33/bd5979b58a03bc7a257df6b2835b98e29aad064082da27ef7d7887825b7b/claude_agent_sdk-0.2.108-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:af31d4aadea5799306da9989c31246710ac248da7506558bbbcca072dcee3a92", size = 74456599, upload-time = "2026-06-23T21:17:36.593Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4a/0e85f2f8b1d49f7c902c10181cbc4e5acccedbe5be0017f88e7a32371de9/claude_agent_sdk-0.2.108-py3-none-win_amd64.whl", hash = "sha256:594e3d37c8d7519f3fe8ddc44fedc821a45d842e4c017ecf17ad4b6e4d6a94c4", size = 74194280, upload-time = "2026-06-23T21:17:42.726Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -336,6 +560,62 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "python_full_version >= '3.12' and platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
 ]
 
 [[package]]
@@ -366,12 +646,68 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "dirhash"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "scantree", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/1f/c8bf92552b7f0a13b9f12b85e3de8df6d9814240e0f8ce8f37433df028b3/dirhash-0.5.0-py3-none-any.whl", hash = "sha256:523dfd6b058c64f45b31604376926c6e2bd2ea301d0df23095d4055674e38b09", size = 13119, upload-time = "2024-08-03T22:14:11.688Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -400,6 +736,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
+name = "fastcore"
+version = "1.13.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/80/8547a93161e6e1d868e1c6d0e6bd9b472486cdfaf8209727a42884b53a7d/fastcore-1.13.6.tar.gz", hash = "sha256:702fe22ff191c005e6909891125e5f7dbdd31bb8f444574e082030a31b960ead", size = 100742, upload-time = "2026-06-18T06:49:07.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/11/867a59ae2d233ce81da373513cabaca2abf03f0180b28e85cf3ae2d5f7f6/fastcore-1.13.6-py3-none-any.whl", hash = "sha256:59264df5bf003fcf44602b7418c6178b37d3c31ae87d8ac106139f716e73711f", size = 105794, upload-time = "2026-06-18T06:49:06.499Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b2/731a6696e37cd20eed353f69a09f37a984a43c9713764ee3f7ad5f57f7f9/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a", size = 516760, upload-time = "2025-10-19T22:25:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/79/c73c47be2a3b8734d16e628982653517f80bbe0570e27185d91af6096507/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00", size = 264748, upload-time = "2025-10-19T22:41:52.873Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c5/84c1eea05977c8ba5173555b0133e3558dc628bcf868d6bf1689ff14aedc/fastuuid-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2fdd48b5e4236df145a149d7125badb28e0a383372add3fbaac9a6b7a394470", size = 254537, upload-time = "2025-10-19T22:33:55.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/23/4e362367b7fa17dbed646922f216b9921efb486e7abe02147e4b917359f8/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74631b8322d2780ebcf2d2d75d58045c3e9378625ec51865fe0b5620800c39d", size = 278994, upload-time = "2025-10-19T22:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/72/3985be633b5a428e9eaec4287ed4b873b7c4c53a9639a8b416637223c4cd/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cffc144dc93eb604b87b179837f2ce2af44871a7b323f2bfed40e8acb40ba8", size = 280003, upload-time = "2025-10-19T22:23:45.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6d/6ef192a6df34e2266d5c9deb39cd3eea986df650cbcfeaf171aa52a059c3/fastuuid-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a771f135ab4523eb786e95493803942a5d1fc1610915f131b363f55af53b219", size = 303583, upload-time = "2025-10-19T22:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/11/8a2ea753c68d4fece29d5d7c6f3f903948cc6e82d1823bc9f7f7c0355db3/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4edc56b877d960b4eda2c4232f953a61490c3134da94f3c28af129fb9c62a4f6", size = 460955, upload-time = "2025-10-19T22:36:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/42/7a32c93b6ce12642d9a152ee4753a078f372c9ebb893bc489d838dd4afd5/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bcc96ee819c282e7c09b2eed2b9bd13084e3b749fdb2faf58c318d498df2efbe", size = 480763, upload-time = "2025-10-19T22:24:28.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e9/a5f6f686b46e3ed4ed3b93770111c233baac87dd6586a411b4988018ef1d/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7a3c0bca61eacc1843ea97b288d6789fbad7400d16db24e36a66c28c268cfe3d", size = 452613, upload-time = "2025-10-19T22:25:06.827Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c9/18abc73c9c5b7fc0e476c1733b678783b2e8a35b0be9babd423571d44e98/fastuuid-0.14.0-cp310-cp310-win32.whl", hash = "sha256:7f2f3efade4937fae4e77efae1af571902263de7b78a0aee1a1653795a093b2a", size = 155045, upload-time = "2025-10-19T22:28:32.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8a/d9e33f4eb4d4f6d9f2c5c7d7e96b5cdbb535c93f3b1ad6acce97ee9d4bf8/fastuuid-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae64ba730d179f439b0736208b4c279b8bc9c089b102aec23f86512ea458c8a4", size = 156122, upload-time = "2025-10-19T22:23:15.59Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
 ]
 
 [[package]]
@@ -547,12 +955,105 @@ http = [
 ]
 
 [[package]]
+name = "ghapi"
+version = "1.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastcore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/e3/133eb1edbbf07e1ef65cbfdd37d1d64078d406d713bb2a77213c95f92960/ghapi-1.0.14.tar.gz", hash = "sha256:5752ff78a48b965522b9f3d41a8953efc469c9535b9fd0ac8be15000b6c99aa9", size = 76904, upload-time = "2026-06-22T03:57:43.514Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/36/3475841d207b73f45fddfac827201919a8cbf7d75fcdf79ff1d9c1216375/ghapi-1.0.14-py3-none-any.whl", hash = "sha256:b92e4187d7a85f73a667c7ce6bda7a4c421e64306af6b9fb112cc58bbbd92b5e", size = 75381, upload-time = "2026-06-22T03:57:41.999Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+]
+
+[[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "harbor"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "claude-agent-sdk", marker = "python_full_version >= '3.12'" },
+    { name = "datasets", marker = "python_full_version >= '3.12'" },
+    { name = "dirhash", marker = "python_full_version >= '3.12'" },
+    { name = "fastapi", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "litellm", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "shortuuid", marker = "python_full_version >= '3.12'" },
+    { name = "supabase", marker = "python_full_version >= '3.12'" },
+    { name = "tenacity", marker = "python_full_version >= '3.12'" },
+    { name = "toml", marker = "python_full_version >= '3.12'" },
+    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/af/9927af345cd7d80e4346539e2340a1cd795861b12fb5d5ffc7b0788a7401/harbor-0.15.0.tar.gz", hash = "sha256:406b20ce520fc1ec12bc9b05396cc91756bb6379fb565a5bc2f2b6759e94cb12", size = 1287081, upload-time = "2026-06-19T22:48:17.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/5a/6e860d3bdbb09c56296d4b57fcebc22f8eb014b06eb3810f9e0a8ab718f7/harbor-0.15.0-py3-none-any.whl", hash = "sha256:a6f7f703d9b008920f07751ae27f6c049afe908bee8199aa6bcc911f6c2aab1b", size = 1463875, upload-time = "2026-06-19T22:48:19.009Z" },
 ]
 
 [[package]]
@@ -588,6 +1089,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -615,6 +1125,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2", marker = "python_full_version >= '3.12'" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
 [[package]]
 name = "huggingface-hub"
 version = "1.13.0"
@@ -636,12 +1160,42 @@ wheels = [
 ]
 
 [[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
 ]
 
 [[package]]
@@ -663,6 +1217,159 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/da/76a2c7e510ba15fe323d9509c223ab272da79ea59f54488f4a78da6426db/jiter-0.15.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:edebcf7d1f601199084bb6e844d7dc67e03e04f6ac786b0332d616635c4ff7a4", size = 310849, upload-time = "2026-05-19T10:06:51.944Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8e/827be942883a4dc0862c48626ff41af3320b1902d136a0bf4b9041f2c567/jiter-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f924585cdacf631cd382b657966847bb537bf9ed0a6f9b991da5f05a631480f", size = 314991, upload-time = "2026-05-19T10:06:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/38/be2832be361ba1b9517c76f46d30b64e985be1dd43c974f4c3a4b1844436/jiter-0.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abbf258599526ad0326fe51e252e24f2bd6f24f1852681b4b78feda3808f1d18", size = 340843, upload-time = "2026-05-19T10:06:55.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d8/90f01fb83c0c7ba509303ec93e32a308fbfa167d264860b01c0fd0dbbd06/jiter-0.15.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7c468136b8bd6bb18c8786e4236a1fa27362f24cb23450ba0cb204ab379b8e6f", size = 365116, upload-time = "2026-05-19T10:06:56.893Z" },
+    { url = "https://files.pythonhosted.org/packages/91/38/94593d34f8c67a0b6f6cbc027f016ffa9780b3a858a7a86f6fd7a15bcc1e/jiter-0.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05906b93d72f03339e6bb7cf8dc10ebda64a0266126eed6beba79e20abcf5fd4", size = 457970, upload-time = "2026-05-19T10:06:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/df/04/d79962dd49d00c97e2a9b4cacea1947904d02135936960351f9a96d4c1a6/jiter-0.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30ce785d2adb8e32c3f7741442370a74834ec4c01f3c48f0750227a0b4ef27d6", size = 375744, upload-time = "2026-05-19T10:07:00.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2e/5d37abe2be0e819c21e2338bebd410e481763ce526a9138c8c3652fa0123/jiter-0.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd73e3da91a0a722d67165e849ce2cdc10de0e0d48738c142be8c6c5f310f4c", size = 349609, upload-time = "2026-05-19T10:07:01.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/90/98768ad2ed90c1fda15d64157de2dfbf73c1c074d4b1bfaca915480bc7cf/jiter-0.15.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:ceb8fc27d38793f9c97149be8302720c5b22e5c195a37bf2c45dc36c4600a512", size = 354366, upload-time = "2026-05-19T10:07:03.587Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c4/fbfb806209f1fe4b7dccdfb07bc62bb044300734a945b06fd64db446ef6a/jiter-0.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d726e3ceeb337191324b49de298142f27c3ad10886341555d1d5315b5f252c6a", size = 393519, upload-time = "2026-05-19T10:07:05.08Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1c/b9c257cd70cb453b6d10f3ebf0402cdb11669ab455389096f09839670290/jiter-0.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c8aea7781d2a372227871de4e1a1332aa96f5a89fd76c5e835dafdbad102887", size = 519952, upload-time = "2026-05-19T10:07:06.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1a/aa85027db7ab15829c12feebbc33b404f53fc399bd559d85fd0d6365ff0d/jiter-0.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cf4bd113a69c0a740e27cb962ce10630c36d2b8f59d759a651b955ee9d18a823", size = 550770, upload-time = "2026-05-19T10:07:08.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/54/8c3f65c8a5687925e84708f19d63f7f37d28e2b86a48d951702ad94424d8/jiter-0.15.0-cp310-cp310-win32.whl", hash = "sha256:d92a5cd21fdb083931d546c207aa29633787c5dc5b02daab2d32b843f88a2c53", size = 209303, upload-time = "2026-05-19T10:07:10.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/0528a1eb9f42dd2d8228a0711458628f35924d131f623eaebc35fd23d3d4/jiter-0.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:e58585a58209d72691ce2d62a9147445f5a87beb0bde97fde284c96ae392a3d1", size = 200404, upload-time = "2026-05-19T10:07:11.426Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899, upload-time = "2026-05-19T10:07:12.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963, upload-time = "2026-05-19T10:07:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730, upload-time = "2026-05-19T10:07:15.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214, upload-time = "2026-05-19T10:07:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527, upload-time = "2026-05-19T10:07:18.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451, upload-time = "2026-05-19T10:07:20.208Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428, upload-time = "2026-05-19T10:07:22.372Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405, upload-time = "2026-05-19T10:07:23.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688, upload-time = "2026-05-19T10:07:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853, upload-time = "2026-05-19T10:07:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016, upload-time = "2026-05-19T10:07:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518, upload-time = "2026-05-19T10:07:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565, upload-time = "2026-05-19T10:07:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488, upload-time = "2026-05-19T10:07:33.846Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585, upload-time = "2026-05-19T10:09:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936, upload-time = "2026-05-19T10:09:37.435Z" },
+    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453, upload-time = "2026-05-19T10:09:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606, upload-time = "2026-05-19T10:09:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "jsonschema-specifications", marker = "python_full_version >= '3.12'" },
+    { name = "referencing", marker = "python_full_version >= '3.12'" },
+    { name = "rpds-py", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.89.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "python_full_version >= '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12'" },
+    { name = "openai", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.12'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/f1/f7cfead063f2ab1877c8fb465d0d7fe300b75f081bcb73525f6d550aeb1c/litellm-1.89.3.tar.gz", hash = "sha256:8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510", size = 14080611, upload-time = "2026-06-20T22:42:26.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/f1/34d174ff1d84e459b30f971606ac9cb7078ad24cd7661e9786b25adf7def/litellm-1.89.3-py3-none-any.whl", hash = "sha256:414ef5aee504b2b3eb1b219d39f1c11902db399cbdbc06e5fb550c15d731abeb", size = 15495226, upload-time = "2026-06-20T22:42:23.156Z" },
 ]
 
 [[package]]
@@ -763,12 +1470,61 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "httpx-sse", marker = "python_full_version >= '3.12'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic-settings", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
+    { name = "python-multipart", marker = "python_full_version >= '3.12'" },
+    { name = "pywin32", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "sse-starlette", marker = "python_full_version >= '3.12'" },
+    { name = "starlette", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.12'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/56/a8d1a1dd705044e0c3534642361e8586db98908b683f8231b9fd39a86209/modal-1.5.1.tar.gz", hash = "sha256:f8fb7f4d3ccc5b774370704b1aabb79e629ea7e6681a7f9671af5cf77161be12", size = 801962, upload-time = "2026-06-23T15:44:18.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/67/c91cb2ee6cbae523ae051f5ecfebd9fc24518fb84b9e92859d32fbbe3a71/modal-1.5.1-py3-none-any.whl", hash = "sha256:49aeda1a4fafc71994c3aa63d3e2321419b586de0303113fa5bfc68f31ad5c95", size = 915761, upload-time = "2026-06-23T15:44:16.48Z" },
 ]
 
 [[package]]
@@ -933,6 +1689,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1005,9 +1770,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
@@ -1082,6 +1850,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
     { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
     { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "distro", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jiter", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "sniffio", marker = "python_full_version >= '3.12'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/d2/ba767f4bbb30776c03d40906a2d3afad716a165ffa1771fc23b8992f7920/openai-2.43.0-py3-none-any.whl", hash = "sha256:65a670b54fadf2268c9e1330133373c963eb779ee969e5cbad419ec2c21dce97", size = 1355077, upload-time = "2026-06-17T17:06:53.614Z" },
 ]
 
 [[package]]
@@ -1165,9 +1952,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1226,12 +2016,61 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "postgrest"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/3e/41909586cb148db0259e0208310067afda4cc097f4c7a779e829c1e68c46/postgrest-2.31.0-py3-none-any.whl", hash = "sha256:c2fd47c94e13ee8335111c4f03c9a24ea9766ce9d35fc3cd7330057c9e7ea0c3", size = 23098, upload-time = "2026-06-04T13:37:19.452Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -1349,6 +2188,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1403,6 +2257,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1537,12 +2400,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -1576,12 +2467,68 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -1649,6 +2596,155 @@ wheels = [
 ]
 
 [[package]]
+name = "realtime"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/60/164246615e8b059f6d53d34648a0784260421ec98a07eb1e45160f063221/realtime-2.31.0-py3-none-any.whl", hash = "sha256:f6e494b53d6a6e80b6efcee6711c8dd40413a52e766271de1bce8ced6c36cc1d", size = 22374, upload-time = "2026-06-04T13:37:21.162Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "rpds-py", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ed/0ad2c8edf634918eb4484365d3819fa7bd7f58daf807fe7fb21812c316e5/regex-2026.5.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9e1328e17c84c1a5d22ec9f785ecef4a967fab9a42b6a8dc3bcbebd0a0c9e44", size = 489438, upload-time = "2026-05-09T23:11:29.374Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/4ed972ad263963b860b7c3e86e0e1bcc791def47b43b8c8efe57e710f139/regex-2026.5.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfe1ce50cbfb569d74e1e4337da6468961f31dbea55fd85aa5de59c0947a805a", size = 291270, upload-time = "2026-05-09T23:11:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/075930d9fa28c4ea1f53398dd015ee7c882f623539759113cda1257f4b82/regex-2026.5.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:15ee42209947f4ca045412eae98416317238163618ace2a8e54f99586a466733", size = 289198, upload-time = "2026-05-09T23:11:35.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/5cdfbf0b5dc6599e1b6131eff43262e5275d4ec3469ce10216061659aadb/regex-2026.5.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4bb445ff3f725f59df8f6014edb547ee928ec7023a774f6a39a3f953038cbb2", size = 784765, upload-time = "2026-05-09T23:11:37.689Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ca/ae5fd6edc59b7f84b904b31d6ec39a860cbcecd10f64bd5a062ca83a4864/regex-2026.5.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:446ddd671e43ab535810c4b21cff7104945c701d4a14d1e6d1cd6f4e445a8bea", size = 852115, upload-time = "2026-05-09T23:11:39.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ce/a91cf555afb51f3b74a182e24ba073b91ea7bb64592fc4b315c111bb19fd/regex-2026.5.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b92817338591505f282cf3864c145244b1edcf5381d237038df955001091538", size = 899503, upload-time = "2026-05-09T23:11:42.48Z" },
+    { url = "https://files.pythonhosted.org/packages/55/7f/725a0a2b245a4cf0c4bab29d0e97c74285d94136a65d1b55a6459a583502/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b8a143aca6c39b446ea8092cde25cc8fe9304d4f5fecfbc1a9dbb0282703c2", size = 794093, upload-time = "2026-05-09T23:11:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2a/996efbd59ce6b5d4a09e3af6180ceb62af171f4a9a6fb557d2f0ae0d462b/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f03aa6898aaaac4592479821df16e68e8d0e29e903e65d8f2dfb2f19028a989", size = 786234, upload-time = "2026-05-09T23:11:46.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0a/8731e8b8806174c9cdd5903f80a14990331c1f42fc4209b540952e9e010d/regex-2026.5.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ed457d8e98ae812ed7732bef7bf78de78e834eae0372a74e23ca90ef21d910f9", size = 769895, upload-time = "2026-05-09T23:11:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0b/932473194bd563f342a412ae2ffbbd6da608306a2bc4e99249a41c2b0b92/regex-2026.5.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71b61c5bfe1c806332defc42ad6c780b3c55f661986d7f40283a3a88274b4c00", size = 774991, upload-time = "2026-05-09T23:11:51.261Z" },
+    { url = "https://files.pythonhosted.org/packages/98/80/9523d196010031df25f7177ee0a467efbee436324038e5d99def17a57515/regex-2026.5.9-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3b1e39888c5e0c7d92cea4fc777396c4a90363b05de75d02eb459a4752200808", size = 848790, upload-time = "2026-05-09T23:11:53.232Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/56987b35e89edf47e4a38cf2845aeee476bfa688a6bdbd3e820cda461dc1/regex-2026.5.9-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:6ba42b2e7e7f46cf68cc6a5ca36fa07959f9bbd9c6bdcc47b6ee76549a590248", size = 757679, upload-time = "2026-05-09T23:11:55.82Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2a/ff713fff0c566507c06a4ce2dc0ae8e7eeebc88811a95fc81cf1e7d534dd/regex-2026.5.9-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:c010eb8caca74bdb40c07498d7ece26b4428fd3f04aa8a72c9ac6f79e8faaac6", size = 837116, upload-time = "2026-05-09T23:11:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/77/90/df6d982b03e3614785c6937ba51b57f6733d97d2ee1c9bc7531dbfab3a54/regex-2026.5.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a6a563446a41adc451393dc6b8e6ad87979efaee3c8738690a8d1b08ebead1b4", size = 782081, upload-time = "2026-05-09T23:11:59.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/4e88a5f7c3e98489aac4dd23142723d907b2a595b4a6abcbacabefeded09/regex-2026.5.9-cp310-cp310-win32.whl", hash = "sha256:954cc214c04663ee6d266fc61739cad83054683048de65c5bd1d640ad28098ac", size = 266247, upload-time = "2026-05-09T23:12:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/4b224cb0582b2dca1786726e6cdabe26abbf757d7f6718332f186da155d2/regex-2026.5.9-cp310-cp310-win_amd64.whl", hash = "sha256:b310768746dd314ea6e2ff4cc89ef215426813396ff4e94ee8e6f7096c8b6e03", size = 278416, upload-time = "2026-05-09T23:12:03.2Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4d/014fbe803204cab0947ee428f09f658a29632053dde1d3c6176bb4f0fd4c/regex-2026.5.9-cp310-cp310-win_arm64.whl", hash = "sha256:19c16ceb4a267a8789e25733e583983eeab9f0f8664e66b0bd1c5d21f14c2d4b", size = 270413, upload-time = "2026-05-09T23:12:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1677,6 +2773,143 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
+    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1702,6 +2935,19 @@ wheels = [
 ]
 
 [[package]]
+name = "scantree"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ce/828467ddfa0d2fe473673026442d2032d552a168e42cfbf25fd0e5264e0c/scantree-0.0.4-py3-none-any.whl", hash = "sha256:7616ab65aa6b7f16fcf8e6fa1d9afaa99a27ab72bba05c61b691853b96763174", size = 20690, upload-time = "2024-08-03T20:08:58.137Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1711,12 +2957,61 @@ wheels = [
 ]
 
 [[package]]
+name = "shortuuid"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "starlette", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
 ]
 
 [[package]]
@@ -1733,6 +3028,113 @@ wheels = [
 ]
 
 [[package]]
+name = "storage3"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/b2/60d86a3a99ae743e8a00a6df912f85269b3bc882ba217b8ce1690881c669/storage3-2.31.0-py3-none-any.whl", hash = "sha256:4bf46e8bea320743179a6beafdc7531c5242495e00e0cc22af7c7a9d69d4ed84", size = 28492, upload-time = "2026-06-04T13:37:22.792Z" },
+]
+
+[[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
+name = "supabase"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "postgrest", marker = "python_full_version >= '3.12'" },
+    { name = "realtime", marker = "python_full_version >= '3.12'" },
+    { name = "storage3", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-auth", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-functions", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/06/5e6f4bf89dedadf81f893832115c1866da1aa093142c9989c2818780dae3/supabase-2.31.0-py3-none-any.whl", hash = "sha256:25f2a99207a75f2d9377e2332783b4389cf56b02cbebdaf0c1743112dcbb704e", size = 16728, upload-time = "2026-06-04T13:37:24.278Z" },
+]
+
+[[package]]
+name = "supabase-auth"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/5e/22f3b0546bb1f0985f06fb1ebf5f6405a3b1bb7a5db01142c26cf148e988/supabase_auth-2.31.0-py3-none-any.whl", hash = "sha256:5e9c8b4ecdee6af04dbcb06455ce78cb15674806fcb6b425170455307d70b0ee", size = 48363, upload-time = "2026-06-04T13:37:26.26Z" },
+]
+
+[[package]]
+name = "supabase-functions"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "strenum", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/79/1a8162ce7d705381a4f2668c0da68e097b103c1aa701418a31da52905c7b/supabase_functions-2.31.0-py3-none-any.whl", hash = "sha256:3fdc4c4766152bfda63bdd0e286fc8a06f50e1280711fae4a1dfc9b7e9ebabc6", size = 8794, upload-time = "2026-06-04T13:37:28.022Z" },
+]
+
+[[package]]
+name = "swebench"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "chardet" },
+    { name = "datasets" },
+    { name = "docker" },
+    { name = "ghapi" },
+    { name = "gitpython" },
+    { name = "modal" },
+    { name = "pre-commit" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+    { name = "unidiff" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/e1/c997299ad7bf088876d30398203aa1eed7dec897670dc1aa35b1d748ffcc/swebench-4.1.0.tar.gz", hash = "sha256:5aaa6a92c2db1aa64892d28a47483ca46a45a15cf1d2df673d7744f71811dc9a", size = 134341, upload-time = "2025-09-11T02:58:00.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/67/981d8b642ac3eac7c8a7b7832ff8b2fb74f96b28b5fcd9a8979879e5c46d/swebench-4.1.0-py3-none-any.whl", hash = "sha256:1243776f720047cc9e20a427f7a52b75c13a07abda6154fb60fe77f82ec8af57", size = 157231, upload-time = "2025-09-11T02:57:58.953Z" },
+]
+
+[[package]]
+name = "synchronicity"
+version = "0.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1c/f51dc54bbd302991026a53f9790735540e0e9e1184e9d5939f02446aa5bc/synchronicity-0.12.5.tar.gz", hash = "sha256:94d96b1d85698e3056b96a793b8c0949af6584e4a7d877fabdeb5385efe230aa", size = 60745, upload-time = "2026-06-18T21:06:23.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/74/ad9b99520f70c0bc3318e582e359d360cfc0f7afd7bf368a7f24013cece7/synchronicity-0.12.5-py3-none-any.whl", hash = "sha256:fdbbb10d437bc08a6b0f814fc66fddd1b58ffed314533d42f1ab555801e781af", size = 41107, upload-time = "2026-06-18T21:06:22.505Z" },
+]
+
+[[package]]
 name = "teich"
 version = "0.2.8"
 source = { editable = "." }
@@ -1740,25 +3142,40 @@ dependencies = [
     { name = "datasets" },
     { name = "fastapi" },
     { name = "huggingface-hub" },
+    { name = "jinja2" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
     { name = "uvicorn" },
-    { name = "websockets" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 
 [package.optional-dependencies]
+bench = [
+    { name = "harbor", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2" },
+    { name = "swebench" },
+]
 dev = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pytest" },
     { name = "ruff" },
 ]
+harbor = [
+    { name = "harbor", marker = "python_full_version >= '3.12'" },
+]
 studio = [
     { name = "fastapi" },
     { name = "uvicorn" },
-    { name = "websockets" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+]
+swe = [
+    { name = "jinja2" },
+    { name = "swebench" },
 ]
 
 [package.metadata]
@@ -1766,21 +3183,132 @@ requires-dist = [
     { name = "datasets", specifier = ">=2.19.0" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "fastapi", marker = "extra == 'studio'", specifier = ">=0.110" },
+    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = ">=0.15.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "huggingface-hub", specifier = ">=0.23.0" },
+    { name = "jinja2", specifier = ">=3.1" },
     { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1" },
+    { name = "jinja2", marker = "extra == 'swe'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "swebench", marker = "extra == 'swe'", specifier = ">=4.1.0" },
+    { name = "teich", extras = ["harbor", "swe"], marker = "extra == 'bench'" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.29" },
     { name = "uvicorn", marker = "extra == 'studio'", specifier = ">=0.29" },
     { name = "websockets", specifier = ">=12" },
     { name = "websockets", marker = "extra == 'studio'", specifier = ">=12" },
 ]
-provides-extras = ["studio", "dev"]
+provides-extras = ["studio", "dev", "harbor", "swe", "bench"]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/e3/03c90dadcf5b3f82b83cee9adee60ef666b329c654f58c066af44eae0287/tiktoken-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:47b1df8d73390a24f94980c75158cdd5c56d256f16d55f30cb49c230caba9ba4", size = 1036627, upload-time = "2026-05-15T04:50:11.229Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/760463e5b2e8ad2bc229ae0a17ecb06727b6cbc094f08d8f65844315632e/tiktoken-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7d40c6c5aab171dcd6eb8455bc567bde404bb9def60cdb8c1299cc782b242bb9", size = 984699, upload-time = "2026-05-15T04:50:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/de/8a/8895f342a6b6aabd1a358e672f6f077b3ae51d0c63ca605d142db3bcd8ab/tiktoken-0.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9b842981fa91accdffd48ff6408a977b7a91c3fbda55d353c3c68114d5c9d69e", size = 1118690, upload-time = "2026-05-15T04:50:14.234Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e0/92557768fb0801f0d9dd9243cb9b6d342900b05e4b1006d4771f49ce233e/tiktoken-0.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ed5a30027cb4d8c7ca8b273d4766f3db3cf58fad9e9f3b1a68a351ffb54873d5", size = 1138423, upload-time = "2026-05-15T04:50:15.668Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b9/a3d99feeedb032ffd09cd6652077f86bdee9a70dd0b990b2b272b445d4c3/tiktoken-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7ab10f4a21c2999846940113f6dbd72e0fa06a24119feddd74cc47e85818e06d", size = 1185077, upload-time = "2026-05-15T04:50:17.19Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/93/bab868277d475dc6d2aaacd34cdd239c282f4908dcc8702e0a3311a8e032/tiktoken-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a2937ad042d49d50eac6e1ba07c5661d4bd3942a5b1e0c0d08475c4df83676e1", size = 1241702, upload-time = "2026-05-15T04:50:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/16/27e9f7e0ed76e501cfefc9fb2112df4c7bf70ca96945b15ecb7615aac860/tiktoken-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:44733b99bfd72b590cd0936b1c01b3b4dd73122db2d544bc1ceeb18a7678c910", size = 876565, upload-time = "2026-05-15T04:50:20.268Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4c/1bc81f4cd53e827c4ee67ca951b5935724716049452d8dfa09b8b82372bb/tiktoken-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7bfe1849caa65d1e1d9871817170ec497bbb7984e182012e1bdce72f66608cdb", size = 1036353, upload-time = "2026-05-15T04:50:21.757Z" },
+    { url = "https://files.pythonhosted.org/packages/75/91/10b9c7076bc02c246c853201fdbbe300a4b8c5ed7b84c25f7403f4e32655/tiktoken-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91c180fe255bd5a86d8316210d2833a1d4d33d026cd86a67812f4773743c8d26", size = 984644, upload-time = "2026-05-15T04:50:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e4/fceae98015fab47fcd49b8bd7f46145bcd187a47e0add1e5378ed67ef980/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:059c8ecf554eb5b41e6e054ba467b871b03277d267dee7244380aca4359747d4", size = 1119261, upload-time = "2026-05-15T04:50:24.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/fe42ad00de01a8c4a49ad8649a2c8a316835a9cad5961b11d21eac0020a5/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:36217497eaffc158607a3b26f065300db2aefd43b115263f3b9688ce38146173", size = 1138253, upload-time = "2026-05-15T04:50:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/ccee1ecccca107e9a16efcecdeeb964c325305038554d466ece65b42338f/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:303f7d91b4fce3baddbcde05c139091d4caa5026ac7214c1dc7ff7a71ee429ff", size = 1185747, upload-time = "2026-05-15T04:50:27.02Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/03/cd0cba295522b91eb55c6b2704f1df895f8226cfe60ab10d4d51d0cc9e69/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d48843bee149630eb735a99e1f4a85b47308d21868ea63163f6e87768d3cfed", size = 1241265, upload-time = "2026-05-15T04:50:28.815Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/a10efd564402d82c2ff50d12057353ace447aa8007deceaa48641f63d35c/tiktoken-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:fc1c44cd37b43fc46bae593129164f4f281e82ea116b57a85aa81bda57eafc94", size = 876509, upload-time = "2026-05-15T04:50:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
 
 [[package]]
 name = "tomli"
@@ -1864,6 +3392,24 @@ wheels = [
 ]
 
 [[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1894,6 +3440,15 @@ wheels = [
 ]
 
 [[package]]
+name = "unidiff"
+version = "0.7.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/48/81be0ac96e423a877754153699731ef439fd7b80b4c8b5425c94ed079ebd/unidiff-0.7.5.tar.gz", hash = "sha256:2e5f0162052248946b9f0970a40e9e124236bf86c82b70821143a6fc1dea2574", size = 20931, upload-time = "2023-03-10T01:05:39.185Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/54/57c411a6e8f7bd7848c8b66e4dcaffa586bf4c02e63f2280db0327a4e6eb/unidiff-0.7.5-py2.py3-none-any.whl", hash = "sha256:c93bf2265cc1ba2a520e415ab05da587370bc2a3ae9e0414329f54f0c2fc09e8", size = 14386, upload-time = "2023-03-10T01:05:36.594Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1917,9 +3472,215 @@ wheels = [
 ]
 
 [[package]]
+name = "virtualenv"
+version = "21.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/5a/2bf22ecb24916983bf1cc0095e7dea2741d14d6553b0d6a2ac8bc96eca93/watchfiles-1.2.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bb68bf4df85abebe5efddc53cf2075520f243a59868d9b3973278b23e76962a9", size = 400471, upload-time = "2026-05-18T04:31:08.908Z" },
+    { url = "https://files.pythonhosted.org/packages/55/70/dea1f6a0e76607841a60fb51af150e70124864673f61704abb62b90cdcc7/watchfiles-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c16cb06dd17d43b9d185094268459eac92c9538356f050e55b54e82cf700e1d4", size = 394599, upload-time = "2026-05-18T04:30:19.845Z" },
+    { url = "https://files.pythonhosted.org/packages/18/52/752dcc7dc817baef5e89518732925795ce52e36a683a9a3c9fb68b21504e/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a0feab9af4c021c581f695258c642b3d10c5fd4c676e33a0d8606425d82631", size = 455458, upload-time = "2026-05-18T04:30:29.126Z" },
+    { url = "https://files.pythonhosted.org/packages/12/48/366ebbb22fcc504c2f72b45f0b7e72f40a18795cc01752c16066d597b67a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a16ffe19bf5cf9f5edaa1ad1dd830c5a816e8feec430c522302ab55483a4b994", size = 460513, upload-time = "2026-05-18T04:31:40.85Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/44/1f9e1b15e7a729062e0d0c3d0d7225ea4ab98b2267ef87287153be2495fc/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204f299afcbd65918ab78dbc52626b0ae45e9d8cef403fdbf33ecf9e40eac66e", size = 493616, upload-time = "2026-05-18T04:30:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/55/8b1086dcc8a1d6a697a62767bd7ea368e74c61c6fd171683cfe24a3fe5d2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11743adfa510bfffebe97659fb280182b5c9b238708f667e866f308c3430dc19", size = 573154, upload-time = "2026-05-18T04:30:37.903Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7a/242f400cc77fafa7b18d53d19d9cb64fc6a6f61f28c55913bae7c674d92a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb72919d93e3a16fc451d3aa3d4b1698423daca1b382d3d959c9ac51297c12a8", size = 467046, upload-time = "2026-05-18T04:30:41.869Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c8/79eee650c62d2c186598489814468e389b5def0ebe755399ff645b35b1b2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62f042afde2dde21ec1d2c1a74361e804673df86f51e418a999c9acfe671b07", size = 457100, upload-time = "2026-05-18T04:31:13.064Z" },
+    { url = "https://files.pythonhosted.org/packages/81/36/519f6dbb7a95e4fe7c1513ed25b1520295ef9905a27f1f2226a73892bfb7/watchfiles-1.2.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:027ae72bfdfd254862065d8b3e2a815c6ab9b1853ce41e6648ece84afd34a551", size = 467038, upload-time = "2026-05-18T04:30:32.915Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/951af6b9f89097e02511122258402cb3578443021930b70cf968d6310dc0/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e1cfd51e97e13ff3bd047c140764d277fc9b95b7cb5da59e46a47d167adab310", size = 632563, upload-time = "2026-05-18T04:30:11.539Z" },
+    { url = "https://files.pythonhosted.org/packages/28/cc/0cba1f0a6117b7ec117271bdc3cb3a5a252005959755a2c09a745e0942cc/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:24b2405c0a46738dd9e1cf7135aa5dbdb9d42d024628651b3b13d5117e99f8df", size = 660851, upload-time = "2026-05-18T04:31:53.186Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/26347558cc8bf6877845e66b315f644d03c173906aa09e233a3f4fd23928/watchfiles-1.2.0-cp310-cp310-win32.whl", hash = "sha256:8c520725602756229f045b032a1ff33d7ef0f7404189d62f6c2438cb6d8ef6a1", size = 277023, upload-time = "2026-05-18T04:30:18.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/68/a5e67b6b68e94f4c1511d61c46c55eba0737583620b6febf194c7b9cc23f/watchfiles-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:03b14855c6f35539e2d95c442ae9530a75762f1e26567152b9ed05f96534a74d", size = 290107, upload-time = "2026-05-18T04:32:09.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3d/8024c801df84d1587740d0359e7fdd80afeae3d159011f3d5376dd82f18e/watchfiles-1.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:704fd259e332e01f9b9c178f4bce9e49027e5587cc2600eeeaf8e76e1c846201", size = 400242, upload-time = "2026-05-18T04:31:19.014Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/f4dfd45323e949984a3a7f9dc31d1cbb049921e7d98253488dda72ccdaa9/watchfiles-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6543cf55d170003296d185c0af981f3e1311564907e1f4e08671fc7693a890a5", size = 394562, upload-time = "2026-05-18T04:30:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/19483ef075d601c409bce8bcbb5c0f81a10876fff870400568f08ce484a1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d8c2394a065ca86f5d2910ff263ae67c127e1376ccc4f9fc35c71db879f80a", size = 456611, upload-time = "2026-05-18T04:30:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6a/cc81fbe7ee42f2f22e661a6e12def7807e01b14b2f39e0ff83fd373fd307/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:772b80df316480d894a0e3165fdd19cf77f5d17f9a787f94029465ad0e3529d1", size = 461379, upload-time = "2026-05-18T04:31:29.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/57/7e669002082c0a0f4fb5113bb70125f7110124b846b0a11bc5ae8e90eac1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d158cd89df6053823533e06fb1d73c549133bff5f0396170c0e53d9559340717", size = 493556, upload-time = "2026-05-18T04:30:05.44Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/f60a2b19807b21fe8281f3a8da4f59eef0d5f96825ac4680ba2d4f2ebf91/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d516b3283a758e087841aedb8031549fb41ced08f3db10aa6d2bf32dc042525b", size = 575255, upload-time = "2026-05-18T04:30:40.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/77f5b5e6efbcd57482f74948ebb1b97e5c0046d6b61475042d830c84b3ff/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53b2290c92e0506d102cd448fbc610d87079553f86caa39d67440856a8b8bba5", size = 467052, upload-time = "2026-05-18T04:31:17.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5a/73e2959af1b97fd5d556f9a8bdba017be23ceeef731869d5eaa0a753d5a3/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a711b51aec4370d0dcda5b6c09463206f133a5759341d7744b953a7b62e1100e", size = 456858, upload-time = "2026-05-18T04:30:30.182Z" },
+    { url = "https://files.pythonhosted.org/packages/50/57/1bc8c27fad7e6c19bddee15d276dbb6ab72480ec01c127afff1673aee417/watchfiles-1.2.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:e2ca07fa7d89195ec0865d3d285666286740bfa83d83e5cee204043a31ecc165", size = 467579, upload-time = "2026-05-18T04:32:15.897Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6c/3c2e44edba3553c5e3c3b8c8a2a6dee6b9e12ae2cf4bd2378bebf9dc3038/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e0618518f282c4ebff60f5e5b1247b6d91bb8b9f4476947563a1e74acc66f3c6", size = 633253, upload-time = "2026-05-18T04:31:37.123Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/d8c84a882ab39bbefcc4915ab3e91830b7a7e990c5570b0b69075aba3faf/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d191c054d0715c3c95c99df9b8dbf6fd096d8c1e021e8f212e1bd8bc444ccb5", size = 660713, upload-time = "2026-05-18T04:31:24.62Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/07/f97736a5fc605364fe67b25e9fa4a6965dfd4840d50c406ada507e9d735f/watchfiles-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9342472aff9b093c5acd4f6d8f70ae0937964ab56542502bcf5579782da69ae8", size = 277222, upload-time = "2026-05-18T04:31:21.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/99/2b04981977fc2608afd60360d928c6aecf6b950292ca221d98f4005f6694/watchfiles-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:dbd6c97045dad81227c8d040173da044c1de08de64a5ea8b555da4aee1d5fa22", size = 290274, upload-time = "2026-05-18T04:31:45.966Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/74/f7f58a7075ee9cf612b0cfcddb78b8cd8234f0742d6f0075cf0da2dde1c6/watchfiles-1.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:57a2d9fa4fb4c2ecae57b13dfff2c7ab53e21a2ba674fe9f05506680fcdcc0d7", size = 283460, upload-time = "2026-05-18T04:31:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f4/7513ef1e85fc4c6331b59479d6d72661fc391fbe543678052ac72c8b6c19/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4674d49eb94706dfe666c069fc0a1b646ffcf920473492e209f6d5f60d3f0cc2", size = 403050, upload-time = "2026-05-18T04:30:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
@@ -2279,4 +4040,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

Adds a benchmark generation mode — `teich generate --mode bench` — that runs reward-labeled benchmark tasks through a pluggable backend (`harbor` or `swe-bench`), harvests each native trace routed by its verifier score into `output/{passed,failed,borderline}/`, and hardens the run for real Docker use (per-task image purge, working Ctrl-C). Everything is opt-in: `--mode prompts` (the default), `github_repo`, and all existing behavior are unchanged, bench lives behind the `teich[harbor]` / `teich[swe]` extras, and the only new core runtime dependency is `jinja2>=3.1` (previously dev-only).

## What's included

### 1. `teich generate --mode bench`
`teich generate` grows a `--mode {prompts,bench}` flag (default `prompts`) and routes bench through a shared driver + harvest so backends stay thin.
- `src/teich/bench/runner.py` `run_bench(cfg, console, resume, refresh)` is imported lazily from `cli.py` so `harbor` / `swebench` stay optional extras; tasks run through a bounded pool sized by `max_concurrency` (default `1`).
- `src/teich/bench/backends/base.py` defines the `BenchBackend` protocol (`require` / `tasks` / `run`, where `run` returns a native trace plus a rewards dict) plus reward routing (`primary_score`, `route_split`: score `1` -> `passed`, `0`/unscored -> `failed`, anything else -> `borderline`) and `harvest()`.
- Native traces land in `output/{passed,failed,borderline}/` with scores + provenance written to `output/metadata/<stem>.json`; filenames are namespaced `bench-<source>-<task>`.
- Bench stays its own dataset, never co-mingled with prompts: rows are written as `bench-<task>.jsonl`, `bench/**` is added to `UPLOAD_IGNORE_PATTERNS`, and a mode guard warns against mixing bench and prompt rows.
- `src/teich/converter.py` excludes bench / verification / sandbox intermediates from the dataset view, while verifier sidecars under `metadata/` are still uploaded as dataset provenance — this is what makes the dataset "verifiable": each row carries its task's reward outcome.
- `src/teich/config.py` adds `bench.sources` (per-source `type` / `source` / `split` / `instances` / `repo` / `version` / `backend`) and `output.bench_dir` (defaults to a sibling `bench` dir beside `traces_dir`, outside the dataset); `config.example.yaml` documents both.
- `--resume` skips already-harvested bench tasks; `--refresh` re-downloads remote `harbor` sources only (swe-bench uses Hugging Face's own dataset cache).

### 2. Harbor backend
- `src/teich/bench/backends/harbor.py` runs Harbor-format tasks by driving the `harbor` package as a library (registry spec, local task dir, or git/HF registry) and reads the verifier's reward dict off the trial env.
- Installed via `teich[harbor]` (`harbor>=0.15.0`, Python >= 3.12).

### 3. SWE-bench backend
SWE-bench ships an evaluation harness, not runnable tasks, so teich runs the agent itself and grades what it produces.
- `src/teich/bench/backends/swebench.py` checks out the clean repo `@ base_commit` inside swebench's prebuilt instance image, renders a thin agent layer on top (`src/teich/bench/templates/agent.dockerfile.j2`), takes the agent's `git diff` as the candidate patch, and grades it with `swebench.run_instance`; the `resolved` verdict becomes the reward (`resolved` -> `passed`, unresolved -> `failed`).
- Installed via `teich[swe]` (`swebench>=4.1.0`); `teich[bench]` = `teich[harbor,swe]`.

### 4. Ctrl-C actually stops a run
The driver ran tasks in a `ThreadPoolExecutor`, but `SIGINT` only reaches the main thread and `with ThreadPoolExecutor` does `shutdown(wait=True)`, so Ctrl-C looked stopped while Docker ground on in the workers.
- `max_concurrency == 1` now runs each task inline on the main thread, so Ctrl-C propagates straight into the Docker call and stops cleanly (the smoke-test / `--resume` path).
- `max_concurrency > 1` cancels queued tasks (`cancel_futures`) and lets the few already inside a Docker call finish before exit (threads can't be signalled).
- Both paths print a "re-run with `--resume`" hint.

### 5. Per-task Docker image purge
harbor's teardown runs `compose down --rmi local`, which does not remove its custom-tagged `hb__<task>` image, so per-task images accumulated and filled the disk.
- On every outcome (passed / failed / error) teich removes the per-task image in a `finally`, gated by `output.keep_bench_images` (default `false` = purge).
- harbor: removes `hb__<task>` read off the trial env, with a deterministic `sanitize("hb__" + task)` fallback covering the error path where the trial never returned.
- swe-bench: removes the per-task agent-layer image but leaves the shared instance image in place (reused, expensive to re-pull).

### 6. Templated dataset card
`src/teich/trace_readme.py` is reworked to render the dataset card from `src/teich/templates/dataset_card.md.j2` off a presentation-only context dict — byte-identical to the previous hand-built card, locked by a golden test.
- `output.license` adds an SPDX id to the frontmatter.
- `output.card_extra` merges arbitrary extra frontmatter keys (reserved keys dropped, dumped via `yaml.safe_dump`).
- `output.readme_template` points at a user `.j2` to fully override the card (rendered with the same context); a `field_validator` errors at config load if the file is missing.
- `size_categories` is auto-populated from the dataset row count using HF's standard buckets (`n<1K` ... `n>1T`).
- `jinja2>=3.1` is promoted from a dev-only to a core dependency; both templates ship in the wheel.

## Validation

- `uv run --extra dev python -m pytest -q` -> 612 passed, 27 skipped
- `uv run --extra dev python -m pytest -q tests/test_bench.py tests/test_swebench.py tests/test_trace_readme.py tests/test_cli.py tests/test_converter.py` -> 168 passed, 2 skipped (bench 31, swe-bench 21, trace_readme 30, cli 29, converter 59)
- Reward routing is covered directly: `test_rewards_resolved`, `test_rewards_unresolved_routes_to_failed`, `test_rewards_resolved_routes_to_passed`
- The card is byte-locked: `test_rendered_card_matches_golden_byte_for_byte`, plus `test_size_category_bucket_boundaries`, `license`, `card_extra`, and custom-template-override tests
- `uv run --extra dev ruff check src/teich/bench src/teich/trace_readme.py src/teich/config.py src/teich/cli.py` -> All checks passed
- `uv build --wheel` -> built `teich-0.2.8-py3-none-any.whl`; confirmed `teich/templates/dataset_card.md.j2` and `teich/bench/templates/agent.dockerfile.j2` are packaged

## Compatibility

`--mode prompts` (the default), `github_repo`, and every existing config key behave exactly as before; bench is opt-in behind `teich[harbor]` / `teich[swe]` / `teich[bench]`, the new `output` knobs all default to today's behavior (`keep_bench_images` defaults to purge, the card renders byte-identically), and the only new core runtime dependency is `jinja2>=3.1` (previously dev-only).

Note: the offline surface (dataset loading, Dockerfile render, reward mapping, backend selection/registration) is unit-tested above; the swe-bench Docker build -> run agent -> grade path is integration-validated only, since CI has no Docker.