### PR TITLE
Upgrade Docker base to Alpine and fix Playwright compatibility

### DIFF
--- a/docker/codex-runtime.Dockerfile
+++ b/docker/codex-runtime.Dockerfile
@@ -14,7 +14,8 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     sudo \
     python3 \
     python3-dev \
-    py3-pip
+    py3-pip \
+    chromium
 
 RUN ln -sf /usr/bin/python3 /usr/local/bin/python && \
     python3 -m venv /opt/venv && \
@@ -22,6 +23,8 @@ RUN ln -sf /usr/bin/python3 /usr/local/bin/python && \
     ln -sf /opt/venv/bin/pip /usr/local/bin/pip && \
     ln -sf /opt/venv/bin/pip3 /usr/local/bin/pip3
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
 ENV VIRTUAL_ENV=/opt/venv
 ARG TEICH_INSTALL_LANGFUSE=0
 
@@ -33,7 +36,7 @@ RUN --mount=type=cache,target=/root/.npm \
     mv /root/.local/bin/uv /usr/local/bin/uv && \
     mv /root/.local/bin/uvx /usr/local/bin/uvx && \
     npm install -g @openai/codex @anthropic-ai/claude-code @mariozechner/pi-coding-agent playwright && \
-    npx playwright install --with-deps chromium && \
+
     node --version && npm --version && npx --version && uv --version && uvx --version && python --version && python3 --version && pip --version && pip3 --version && codex --version && claude --version && pi --version
 
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/docker/codex-runtime.Dockerfile
+++ b/docker/codex-runtime.Dockerfile
@@ -1,23 +1,20 @@
 # syntax=docker/dockerfile:1
-FROM node:22-slim
+FROM node:26.4.0-alpine3.24
 
 # Install system dependencies with cache mount and minimal packages
 # Removed: build-essential (only needed for compiling, not runtime)
 # Added: --no-install-recommends to skip extra packages
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update && apk add \
+    build-base \
+    bash \
     git \
     curl \
     ca-certificates \
     sudo \
     python3 \
     python3-dev \
-    python3-minimal \
-    python3-pip \
-    python3-venv \
-    && rm -rf /var/lib/apt/lists/*
+    py3-pip
 
 RUN ln -sf /usr/bin/python3 /usr/local/bin/python && \
     python3 -m venv /opt/venv && \
@@ -75,14 +72,14 @@ RUN if [ "$TEICH_INSTALL_LANGFUSE" = "1" ]; then \
 
 # Create working directory and user in one layer
 WORKDIR /workspace
-RUN useradd -m -s /bin/bash codex && \
+RUN adduser -D -s /bin/bash codex && \
     mkdir -p /home/codex/.codex/sessions && \
     mkdir -p /home/codex/.claude && \
     mkdir -p /home/codex/.hermes && \
     printf 'codex ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/codex && \
     chmod 0440 /etc/sudoers.d/codex && \
-    printf '#!/usr/bin/env bash\nexec sudo /usr/bin/apt-get "$@"\n' > /usr/local/bin/apt-get && \
-    printf '#!/usr/bin/env bash\nexec sudo /usr/bin/apt "$@"\n' > /usr/local/bin/apt && \
+    printf '#!/usr/bin/env bash\nif [ "$1" = "install" ]; then shift; pkgs=(); for i in "$@"; do if [[ "$i" != -* ]]; then pkgs+=("$i"); fi; done; exec sudo /sbin/apk add "${pkgs[@]}"; elif [ "$1" = "update" ]; then exec sudo /sbin/apk update; else exec sudo /sbin/apk "$@"; fi\n' > /usr/local/bin/apt-get && \
+    printf '#!/usr/bin/env bash\nif [ "$1" = "install" ]; then shift; pkgs=(); for i in "$@"; do if [[ "$i" != -* ]]; then pkgs+=("$i"); fi; done; exec sudo /sbin/apk add "${pkgs[@]}"; elif [ "$1" = "update" ]; then exec sudo /sbin/apk update; else exec sudo /sbin/apk "$@"; fi\n' > /usr/local/bin/apt && \
     chmod +x /usr/local/bin/apt-get /usr/local/bin/apt && \
     chown -R codex:codex /home/codex /workspace ${PLAYWRIGHT_BROWSERS_PATH} ${VIRTUAL_ENV}
 


### PR DESCRIPTION
Updates the `codex-runtime.Dockerfile` to use `node:26.4.0-alpine3.24` resolving the Snyk security vulnerability reports regarding the Debian base image. Additionally, Playwright has been configured to use Alpine's native Chromium package to fix compatibility issues.