### PR TITLE
Update Docker base image to node:26.4.0-slim

### DIFF
--- a/docker/codex-runtime.Dockerfile
+++ b/docker/codex-runtime.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22-slim
+FROM node:26.4.0-slim
 
 # Install system dependencies with cache mount and minimal packages
 # Removed: build-essential (only needed for compiling, not runtime)


### PR DESCRIPTION
This PR fixes the Snyk vulnerabilities while correctly preserving Debian slim compatibility for the codex agents. The previous PR #19 was accidentally closed.