### PR TITLE
perf: skip rewriting files untouched by in-place anonymization

### DIFF
--- a/src/teich/anonymize.py
+++ b/src/teich/anonymize.py
@@ -107,7 +107,8 @@ def _anonymize_file(source: Path, destination: Path) -> AnonymizeFileReport:
                 shutil.copy2(source, destination)
             return AnonymizeFileReport(path=source, output_path=destination)
         text = anonymizer.anonymize_text(original)
-        destination.write_text(text, encoding="utf-8")
+        if text != original or source.resolve() != destination.resolve():
+            destination.write_text(text, encoding="utf-8")
 
     return AnonymizeFileReport(
         path=source,
@@ -132,6 +133,7 @@ def _anonymize_jsonl_file(source: Path, destination: Path, anonymizer: "TraceAno
             ) as temp_handle,
         ):
             temp_path = Path(temp_handle.name)
+            changed = False
             for raw_line in handle:
                 stripped = raw_line.strip()
                 if not stripped:
@@ -140,12 +142,16 @@ def _anonymize_jsonl_file(source: Path, destination: Path, anonymizer: "TraceAno
                 try:
                     value = json.loads(raw_line)
                 except json.JSONDecodeError:
-                    temp_handle.write(anonymizer.anonymize_text(raw_line))
+                    anonymized_line = anonymizer.anonymize_text(raw_line)
+                    if anonymized_line != raw_line:
+                        changed = True
+                    temp_handle.write(anonymized_line)
                     continue
                 anonymized = anonymizer.anonymize_value(value)
                 if anonymized == value:
                     temp_handle.write(raw_line)
                     continue
+                changed = True
                 line = json.dumps(anonymized, ensure_ascii=False, separators=(",", ":"))
                 line = line.replace("\u0085", "\\u0085").replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
                 temp_handle.write(line + "\n")
@@ -161,7 +167,10 @@ def _anonymize_jsonl_file(source: Path, destination: Path, anonymizer: "TraceAno
         )
         return
     if temp_path is not None:
-        temp_path.replace(destination)
+        if not changed and source.resolve() == destination.resolve():
+            temp_path.unlink()
+        else:
+            temp_path.replace(destination)
 
 
 class TraceAnonymizer:


### PR DESCRIPTION
In-place anonymization (`teich extract`'s default post-pass, `teich anonymize --in-place`) always replaced the destination with the freshly written temp file, even when zero lines changed — every clean trace got rewritten and its mtime churned on every run.

This tracks whether any line was actually modified while streaming; when an in-place run leaves the content identical, the temp file is discarded instead of replacing the destination. Whole-text (non-jsonl) files get the same check. Copy-to-other-destination behavior is unchanged.

## Testing
- `pytest tests/test_extract_anonymize_cli.py` — 32 passed
- manual check: clean file's mtime untouched after in-place run, secret-bearing sibling still anonymized

🤖 Generated with [Claude Code](https://claude.com/claude-code)