### PR TITLE
perf: anonymize files in parallel with a process pool

### DIFF
--- a/src/teich/anonymize.py
+++ b/src/teich/anonymize.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 import hashlib
+import os
 import json
 import re
 import shutil
@@ -23,6 +25,10 @@ TEXT_EXTENSIONS = {
     ".toml",
     ".log",
 }
+
+# ponytail: process startup isn't free — only fan out when there are enough
+# files for the parallelism to pay for itself.
+_MIN_FILES_FOR_PARALLEL = 8
 
 
 @dataclass
@@ -73,11 +79,17 @@ def anonymize_path(input_path: Path, output_path: Path, *, in_place: bool = Fals
         report.files.append(file_report)
         return report
 
-    for source_file in sorted(path for path in input_path.rglob("*") if path.is_file()):
-        relative_path = source_file.relative_to(input_path)
-        destination = source_file if in_place else output_path / relative_path
-        file_report = _anonymize_file(source_file, destination)
-        report.files.append(file_report)
+    source_files = sorted(path for path in input_path.rglob("*") if path.is_file())
+    destinations = [source if in_place else output_path / source.relative_to(input_path) for source in source_files]
+    workers = min(os.cpu_count() or 1, len(source_files))
+    if workers > 1 and len(source_files) >= _MIN_FILES_FOR_PARALLEL:
+        # Each file is anonymized independently (fresh TraceAnonymizer per
+        # file), so files can be processed in parallel safely.
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            report.files.extend(executor.map(_anonymize_file, source_files, destinations))
+    else:
+        for source_file, destination in zip(source_files, destinations):
+            report.files.append(_anonymize_file(source_file, destination))
     return report
 
 

--- a/src/teich/anonymize.py
+++ b/src/teich/anonymize.py
@@ -11,6 +11,7 @@ import json
 import re
 import shutil
 import string
+import sys
 from tempfile import NamedTemporaryFile
 from typing import Any
 
@@ -29,6 +30,14 @@ TEXT_EXTENSIONS = {
 # ponytail: process startup isn't free — only fan out when there are enough
 # files for the parallelism to pay for itself.
 _MIN_FILES_FOR_PARALLEL = 8
+_WINDOWS_MAX_PROCESS_WORKERS = 61
+
+
+def _process_worker_count(file_count: int) -> int:
+    workers = min(os.cpu_count() or 1, file_count)
+    if sys.platform == "win32":
+        workers = min(workers, _WINDOWS_MAX_PROCESS_WORKERS)
+    return workers
 
 
 @dataclass
@@ -81,7 +90,7 @@ def anonymize_path(input_path: Path, output_path: Path, *, in_place: bool = Fals
 
     source_files = sorted(path for path in input_path.rglob("*") if path.is_file())
     destinations = [source if in_place else output_path / source.relative_to(input_path) for source in source_files]
-    workers = min(os.cpu_count() or 1, len(source_files))
+    workers = _process_worker_count(len(source_files))
     if workers > 1 and len(source_files) >= _MIN_FILES_FOR_PARALLEL:
         # Each file is anonymized independently (fresh TraceAnonymizer per
         # file), so files can be processed in parallel safely.

--- a/tests/test_extract_anonymize_cli.py
+++ b/tests/test_extract_anonymize_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
+from teich import anonymize as anonymize_module
 from teich.converter import convert_traces_to_training_data
 from teich import extract as extract_module
 from teich.extract import CURSOR_EXTRACTION_NOTICE, default_session_sources
@@ -1640,6 +1641,13 @@ def test_anonymize_replaces_emails_keys_and_home_usernames_consistently(tmp_path
     assert "email=2" in result.output
     assert "username=7" in result.output
     assert "api_key=1" in result.output
+
+
+def test_anonymize_parallel_worker_count_caps_windows(monkeypatch):
+    monkeypatch.setattr(anonymize_module.os, "cpu_count", lambda: 128)
+    monkeypatch.setattr(anonymize_module.sys, "platform", "win32")
+
+    assert anonymize_module._process_worker_count(100) == 61
 
 
 def test_anonymize_jsonl_preserves_valid_json_after_escaped_path_replacements(tmp_path: Path):


### PR DESCRIPTION
Directory anonymization processed files strictly sequentially, but each file already gets its own `TraceAnonymizer` instance (replacement maps are per-trace by design), so files are fully independent.

This fans the per-file work out over a `ProcessPoolExecutor` sized to `os.cpu_count()` (falling back to 1 when unavailable — no hardware assumptions). Batches under 8 files keep the sequential path, since process startup would cost more than it saves. Report ordering, per-file scoping, and output are unchanged; `executor.map` preserves the sorted file order.

## Testing
- `pytest tests/test_extract_anonymize_cli.py` — 32 passed
- 24-file synthetic export: all 7200 seeded keys redacted, per-file report order preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)