### PR TITLE
Add Gemma 4 support for E4B, 26B‑A4B, 31B

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -47,6 +47,33 @@ trainer.train()
 
 Keep `packing=False` for this flow because packed datasets merge row boundaries before masking.
 
+## Live Gemma 4 Models
+
+For the live Google Gemma 4 instruction checkpoints, keep the chat template
+loaded from the selected model repository. The supported smoke-tested targets
+are:
+
+- `google/gemma-4-E4B-it`
+- `google/gemma-4-26B-A4B-it`
+- `google/gemma-4-31B-it`
+
+Pass `chat_template_kwargs={"enable_thinking": True, "preserve_thinking": True}`
+to `prepare_data()`. Do not replace `tokenizer.chat_template` unless you are
+intentionally testing a maintained fork. Teich supervises the closing
+`<turn|>` token for completed Gemma responses while keeping system, user, and
+tool-response context masked.
+
+`gemma4_example.py` uses the live remote template by default. Set
+`CHAT_TEMPLATE_PATH` only to opt into a local custom template, and set
+`MODEL_REVISION` when a reproducible non-`main` revision is required. Set
+`HF_TOKEN` to an account that has accepted the Gemma repository terms when the
+checkpoint is not already available through the local Hugging Face login.
+
+Run the example in a dedicated, internally consistent Unsloth training
+environment and check it with `python -m pip check` before a long run. Teich's
+core environment does not pin the CUDA, PyTorch, Unsloth, and TRL stack because
+those versions depend on the host GPU and CUDA runtime.
+
 ## What `mask_data()` Does
 
 Before `mask_data()`, the trainer dataset usually contains:

--- a/gemma4_example.py
+++ b/gemma4_example.py
@@ -1,15 +1,22 @@
 # -*- coding: utf-8 -*-
 import os
+
+# Gemma 4's fused-loss path has had silent zero-gradient failures with
+# response-only labels. Prefer the correctness path unless the caller has
+# explicitly validated and enabled the fused implementation.
+os.environ.setdefault("UNSLOTH_RETURN_LOGITS", "1")
+
 from unsloth import FastModel
 from trl import SFTConfig, SFTTrainer
 from teich import mask_data, prepare_data
 
 MAX_SEQ_LEN = 16384
 MODEL_NAME = os.environ.get("MODEL_NAME", "google/gemma-4-26B-A4B-it")
+MODEL_REVISION = os.environ.get("MODEL_REVISION", "main")
 OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "outputs/gemma-tool-sft")
 HUB_REPO_ID = os.environ.get("HUB_REPO_ID") or ""
 HF_TOKEN = os.environ.get("HF_TOKEN", "")
-CHAT_TEMPLATE_PATH = os.environ.get("CHAT_TEMPLATE_PATH") or "gemma-template.jinja"
+CHAT_TEMPLATE_PATH = os.environ.get("CHAT_TEMPLATE_PATH")
 
 model, tokenizer = FastModel.from_pretrained(
     model_name=MODEL_NAME,
@@ -17,8 +24,12 @@ model, tokenizer = FastModel.from_pretrained(
     load_in_4bit=False,
     load_in_8bit=False,
     full_finetuning=False,
+    revision=MODEL_REVISION,
+    token=HF_TOKEN or None,
 )
 
+# By default, retain the template shipped by the selected live model revision.
+# CHAT_TEMPLATE_PATH is an explicit escape hatch for controlled experiments.
 if CHAT_TEMPLATE_PATH:
     with open(CHAT_TEMPLATE_PATH, "r", encoding="utf-8") as f:
         custom_chat_template = f.read()
@@ -57,14 +68,14 @@ train_dataset = prepare_data(
     hf_token=HF_TOKEN,
     chat_template_kwargs={"enable_thinking": True, "preserve_thinking": True},
     max_length=MAX_SEQ_LEN,
-    drop_oversized_examples=False,
+    oversized_policy="trim_followups",
     tokenize=True,
     strict=True,
 )
 
 trainer = SFTTrainer(
     model=model,
-    tokenizer=tokenizer,
+    processing_class=tokenizer,
     train_dataset=train_dataset,
     eval_dataset=None,
     args=SFTConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "teich"
-version = "0.3.3"
+version = "0.3.4"
 description = "Turn coding agent traces into auditable supervised fine-tuning data"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/teich/__init__.py
+++ b/src/teich/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 from .audit import SFTAuditReport, audit_sft_dataset
 from .config import Config, load_config

--- a/src/teich/formatter.py
+++ b/src/teich/formatter.py
@@ -585,7 +585,10 @@ def _gemma_like_supervised_spans(text: str) -> list[tuple[int, int]]:
         block_end = turn_matches[index + 1].start() if index + 1 < len(turn_matches) else len(text)
         turn_end = text.find(_GEMMA_TURN_END, block_start, block_end)
         if turn_end >= 0:
-            block_end = turn_end
+            # The model emits <turn|> to terminate a completed response. Keep
+            # that token in the target so response-only SFT still teaches the
+            # live Gemma 4 stopping contract.
+            block_end = turn_end + len(_GEMMA_TURN_END)
         supervised_start = block_start + len(_GEMMA_ASSISTANT_TURN_PREFIX)
         if supervised_start < block_end:
             supervised_spans.append((supervised_start, block_end))
@@ -1387,7 +1390,29 @@ def _select_supervised_spans(
         selected = _subtract_spans(selected, _source_spans_for_kind(spans, _SPAN_KIND_SYSTEM))
     if not train_on_developer:
         selected = _subtract_spans(selected, _source_spans_for_kind(spans, _SPAN_KIND_DEVELOPER))
-    return _merge_spans(selected)
+    selected = _merge_spans(selected)
+
+    # A Gemma turn terminator is useful only when the same model turn still
+    # contains an enabled training target. For example, excluding reasoning
+    # from a reasoning-only response must not keep the row alive solely by
+    # labeling its trailing <turn|> token.
+    orphaned_turn_ends: list[tuple[int, int]] = []
+    turn_matches = list(_GEMMA_TURN_START_PATTERN.finditer(text))
+    for index, match in enumerate(turn_matches):
+        if match.group(1) != "model":
+            continue
+        block_end = turn_matches[index + 1].start() if index + 1 < len(turn_matches) else len(text)
+        turn_end = text.find(_GEMMA_TURN_END, match.end(), block_end)
+        if turn_end < 0:
+            continue
+        has_selected_content = any(
+            text[max(start, match.end()) : min(end, turn_end)].strip()
+            for start, end in selected
+            if start < turn_end and end > match.end()
+        )
+        if not has_selected_content:
+            orphaned_turn_ends.append((turn_end, turn_end + len(_GEMMA_TURN_END)))
+    return _subtract_spans(selected, orphaned_turn_ends)
 
 
 def _labels_from_offsets(

--- a/src/teich/formatter.py
+++ b/src/teich/formatter.py
@@ -1392,11 +1392,14 @@ def _select_supervised_spans(
         selected = _subtract_spans(selected, _source_spans_for_kind(spans, _SPAN_KIND_DEVELOPER))
     selected = _merge_spans(selected)
 
-    # A Gemma turn terminator is useful only when the same model turn still
-    # contains an enabled training target. For example, excluding reasoning
-    # from a reasoning-only response must not keep the row alive solely by
-    # labeling its trailing <turn|> token.
+    # A Gemma turn terminator is useful exactly when the same model turn still
+    # contains an enabled training target. It is initially part of the inferred
+    # final-answer span, so restore it when final answers are disabled but an
+    # enabled reasoning or tool-call target remains. Conversely, do not keep a
+    # reasoning-only row alive solely by labeling <turn|> after reasoning was
+    # excluded.
     orphaned_turn_ends: list[tuple[int, int]] = []
+    retained_turn_ends: list[tuple[int, int]] = []
     turn_matches = list(_GEMMA_TURN_START_PATTERN.finditer(text))
     for index, match in enumerate(turn_matches):
         if match.group(1) != "model":
@@ -1405,13 +1408,21 @@ def _select_supervised_spans(
         turn_end = text.find(_GEMMA_TURN_END, match.end(), block_end)
         if turn_end < 0:
             continue
+        turn_end_span = (turn_end, turn_end + len(_GEMMA_TURN_END))
+        turn_end_was_supervised = any(
+            span["start"] <= turn_end and span["end"] >= turn_end_span[1]
+            for span in spans
+        )
         has_selected_content = any(
             text[max(start, match.end()) : min(end, turn_end)].strip()
             for start, end in selected
             if start < turn_end and end > match.end()
         )
-        if not has_selected_content:
-            orphaned_turn_ends.append((turn_end, turn_end + len(_GEMMA_TURN_END)))
+        if has_selected_content and turn_end_was_supervised:
+            retained_turn_ends.append(turn_end_span)
+        elif not has_selected_content:
+            orphaned_turn_ends.append(turn_end_span)
+    selected = _merge_spans(selected + retained_turn_ends)
     return _subtract_spans(selected, orphaned_turn_ends)
 
 

--- a/src/teich/runner.py
+++ b/src/teich/runner.py
@@ -144,11 +144,12 @@ TEXT_SUBPROCESS_KWARGS: dict[str, Any] = {
     "encoding": "utf-8",
     "errors": "replace",
 }
+SUBPROCESS_CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 if os.name == "nt":
     # Teich owns these background CLI processes and consumes their output via
     # pipes. They do not need a host console, and suppressing one prevents
     # conhost.exe accumulation in long Windows generation runs.
-    TEXT_SUBPROCESS_KWARGS["creationflags"] = subprocess.CREATE_NO_WINDOW
+    TEXT_SUBPROCESS_KWARGS["creationflags"] = SUBPROCESS_CREATE_NO_WINDOW
 
 
 def _terminate_process_tree(

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -115,3 +115,13 @@ def test_teich_example_has_single_safe_training_flow():
     assert sum(isinstance(node, ast.Call) and getattr(node.func, "attr", "") == "train" for node in ast.walk(tree)) == 1
 
 
+def test_gemma4_example_uses_live_remote_template_and_safe_masks():
+    source = Path("gemma4_example.py").read_text(encoding="utf-8")
+
+    assert 'os.environ.setdefault("UNSLOTH_RETURN_LOGITS", "1")' in source
+    assert 'MODEL_REVISION = os.environ.get("MODEL_REVISION", "main")' in source
+    assert 'CHAT_TEMPLATE_PATH = os.environ.get("CHAT_TEMPLATE_PATH")' in source
+    assert 'or "gemma-template.jinja"' not in source
+    assert "token=HF_TOKEN or None" in source
+    assert 'oversized_policy="trim_followups"' in source
+    assert "processing_class=tokenizer" in source

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1101,11 +1101,12 @@ def test_prepare_and_mask_can_exclude_reasoning_from_gemma_style_supervision():
     row = training_data[0]
     assert row["text"] == "<bos><|turn>user\nhello<turn|>\n<|turn>model\n<|channel>thought\nthink\n<channel|>world<turn|>\n"
     supervised_text = tokenizer.decode([token for token in row["labels"] if token != -100])
-    assert supervised_text == "world"
+    assert supervised_text == "world<turn|>"
     masked_text = tokenizer.decode(
         [token_id for token_id, label in zip(row["input_ids"], row["labels"]) if label == -100]
     )
     assert "<|channel>thought\nthink\n<channel|>" in masked_text
+    assert "<turn|>" not in masked_text.rsplit("<|turn>model\n", 1)[-1]
 
 
 def test_prepare_and_mask_falls_back_when_gemma_drops_marker_boundaries_with_thinking_disabled():
@@ -1139,7 +1140,7 @@ def test_prepare_and_mask_falls_back_when_gemma_drops_marker_boundaries_with_thi
 
     row = training_data[0]
     supervised_text = tokenizer.decode([token for token in row["labels"] if token != -100])
-    assert supervised_text == "world"
+    assert supervised_text == "world<turn|>"
 
 
 def test_prepare_data_rejects_reserved_chat_template_kwargs():

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -27,6 +27,8 @@ def prepare_and_mask_for_test(
     tools_column="tools",
     chat_template_kwargs=None,
     train_on_reasoning=True,
+    train_on_final_answers=True,
+    train_on_tools=True,
     max_length=None,
     include_debug_columns=False,
     drop_oversized_examples=True,
@@ -51,7 +53,15 @@ def prepare_and_mask_for_test(
         args=SimpleNamespace(dataset_text_field="text", max_length=max_length if drop_oversized_examples else None, packing=False),
         tokenizer=tokenizer,
     )
-    trainer = mask_data(trainer, tokenizer=tokenizer, train_on_reasoning=train_on_reasoning, audit=False, verbose=False)
+    trainer = mask_data(
+        trainer,
+        tokenizer=tokenizer,
+        train_on_reasoning=train_on_reasoning,
+        train_on_final_answers=train_on_final_answers,
+        train_on_tools=train_on_tools,
+        audit=False,
+        verbose=False,
+    )
     training_data = trainer.train_dataset
     if include_debug_columns:
         rows = []
@@ -1107,6 +1117,85 @@ def test_prepare_and_mask_can_exclude_reasoning_from_gemma_style_supervision():
     )
     assert "<|channel>thought\nthink\n<channel|>" in masked_text
     assert "<turn|>" not in masked_text.rsplit("<|turn>model\n", 1)[-1]
+
+
+def test_gemma_turn_end_remains_supervised_when_only_reasoning_is_enabled():
+    tokenizer = GemmaLikeOffsetTokenizer()
+    dataset = Dataset.from_list(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "world", "reasoning_content": "think"},
+                ],
+                "tools": [],
+            }
+        ]
+    )
+
+    training_data = prepare_and_mask_for_test(
+        dataset,
+        tokenizer,
+        train_on_reasoning=True,
+        train_on_final_answers=False,
+    )
+
+    row = training_data[0]
+    supervised_text = tokenizer.decode([token for token in row["labels"] if token != -100])
+    assert "think" in supervised_text
+    assert "world" not in supervised_text
+    assert supervised_text.endswith("<turn|>")
+
+
+def test_gemma_turn_end_remains_supervised_when_only_tool_call_is_enabled():
+    class ToolTurnClosingGemmaTokenizer(GemmaLikeOffsetTokenizer):
+        def apply_chat_template(self, *args, **kwargs):
+            rendered = super().apply_chat_template(*args, **kwargs)
+            if isinstance(rendered, str):
+                rendered = rendered.replace("<tool_call|>", "<tool_call|><turn|>\n")
+            return rendered
+
+    tokenizer = ToolTurnClosingGemmaTokenizer()
+    dataset = Dataset.from_list(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "list files"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "bash", "arguments": {"command": "ls"}},
+                            }
+                        ],
+                    },
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "bash", "parameters": {"type": "object"}},
+                    }
+                ],
+            }
+        ]
+    )
+
+    training_data = prepare_and_mask_for_test(
+        dataset,
+        tokenizer,
+        train_on_reasoning=False,
+        train_on_final_answers=False,
+        train_on_tools=True,
+    )
+
+    row = training_data[0]
+    supervised_text = tokenizer.decode([token for token in row["labels"] if token != -100])
+    assert "<|tool_call>call:bash" in supervised_text
+    assert "ls" in supervised_text
+    assert supervised_text.endswith("<turn|>")
 
 
 def test_prepare_and_mask_falls_back_when_gemma_drops_marker_boundaries_with_thinking_disabled():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -72,6 +72,14 @@ def test_windows_owned_process_cleanup_kills_entire_tree():
     process.wait.assert_called_once_with(timeout=5)
 
 
+def test_subprocess_creation_flags_are_platform_safe():
+    assert runner_module.SUBPROCESS_CREATE_NO_WINDOW == getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    if os.name == "nt":
+        assert runner_module.TEXT_SUBPROCESS_KWARGS["creationflags"] == runner_module.SUBPROCESS_CREATE_NO_WINDOW
+    else:
+        assert "creationflags" not in runner_module.TEXT_SUBPROCESS_KWARGS
+
+
 def _filesystem_preserves_chmod(tmp_path: Path) -> bool:
     probe = tmp_path / "chmod-probe"
     probe.write_text("", encoding="utf-8")

--- a/tests/test_tokenizer_smoke.py
+++ b/tests/test_tokenizer_smoke.py
@@ -11,6 +11,8 @@ from teich import mask_data, prepare_data
 
 TOKENIZER_SMOKE_MODELS = [
     pytest.param("unsloth/Qwen3.5-0.8B", {"enable_thinking": True}, id="unsloth-qwen3.5"),
+    pytest.param("google/gemma-4-E4B-it", {"enable_thinking": True}, id="gemma-4-e4b-it"),
+    pytest.param("google/gemma-4-26B-A4B-it", {"enable_thinking": True}, id="gemma-4-26b-a4b-it"),
     pytest.param("google/gemma-4-31B-it", {"enable_thinking": True}, id="gemma-4-31b-it"),
 ]
 
@@ -71,7 +73,7 @@ def test_real_tokenizer_prepare_and_mask_tool_dataset(model_id: str, chat_templa
     try:
         tokenizer = transformers.AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
     except Exception as exc:
-        pytest.skip(f"Could not load tokenizer for {model_id}: {exc}")
+        pytest.fail(f"Could not load tokenizer for {model_id}: {exc}")
 
     prepared = prepare_data(
         _tool_call_dataset(),
@@ -107,3 +109,19 @@ def test_real_tokenizer_prepare_and_mask_tool_dataset(model_id: str, chat_templa
     assert "Found project files." in supervised_text
     assert "SECRET_TOOL_OUTPUT" not in supervised_text
     assert "SECRET_TOOL_OUTPUT" in masked_text
+
+    if model_id.startswith("google/gemma-4-"):
+        eot_token_id = tokenizer.convert_tokens_to_ids("<turn|>")
+        assert eot_token_id in supervised_ids
+        assert supervised_text.endswith("<turn|>")
+
+        source_row = _tool_call_dataset()[0]
+        generation_messages = source_row["messages"][:-1]
+        generation_prompt = tokenizer.apply_chat_template(
+            generation_messages,
+            tools=source_row["tools"],
+            tokenize=False,
+            add_generation_prompt=True,
+            **chat_template_kwargs,
+        )
+        assert generation_prompt.endswith("<|channel>thought\n")

--- a/uv.lock
+++ b/uv.lock
@@ -2123,7 +2123,7 @@ wheels = [
 
 [[package]]
 name = "teich"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
Implemented and pushed live Gemma 4 support for:

- [[E4B](https://huggingface.co/google/gemma-4-E4B-it)](https://huggingface.co/google/gemma-4-E4B-it)
- [[26B-A4B](https://huggingface.co/google/gemma-4-26B-A4B-it)](https://huggingface.co/google/gemma-4-26B-A4B-it)
- [[31B](https://huggingface.co/google/gemma-4-31B-it)](https://huggingface.co/google/gemma-4-31B-it)

Key fixes:

- [gemma4_example.py](C:/Users/aranr/Documents/github/teich/gemma4_example.py:7) now uses each model’s live remote template by default instead of silently loading the stale local template.
- `<turn|>` is now supervised as Gemma’s response terminator, without keeping reasoning-only or otherwise untrainable rows alive.
- Added revision selection, gated-model `HF_TOKEN` forwarding, safe oversized-row trimming, current TRL `processing_class`, and the Unsloth zero-gradient workaround.
- Live regression coverage checks masking and the thinking-generation prefix for all three models.
- Current tested remote revisions:
  - E4B: `ee0ef6023621cff504d758262d4e04895a5af4a2`
  - 26B-A4B: `4d7ae4984b7db7de8f8457170b3f1a419ee76d52`
  - 31B: `842da3794eaa0b77d5f08bae87a17459d91ff475`

Verification:

- Live tokenizer/template matrix: `4 passed`
- Full suite: `664 passed, 6 skipped`
- Focused masking suite: `100 passed`
- Ruff and mypy: clean
- Verified tests import the checkout’s Teich 0.3.3